### PR TITLE
Fix: missing content type handling in Allowed child types field and fieldsetting.

### DIFF
--- a/src/ContentRepository/Fields/AllowedChildTypesField.cs
+++ b/src/ContentRepository/Fields/AllowedChildTypesField.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using SenseNet.ContentRepository.Schema;
+using SenseNet.Diagnostics;
 
 namespace SenseNet.ContentRepository.Fields
 {
@@ -32,14 +33,38 @@ namespace SenseNet.ContentRepository.Fields
         protected override bool ParseValue(string value)
         {
             var x = value.Split(ContentType.XmlListSeparators, StringSplitOptions.RemoveEmptyEntries);
-            var ctList = new ContentType[x.Length];
-            for (int i = 0; i < x.Length; i++)
-			{
-                var ct = ContentType.GetByName(x[i].Trim());
+            var ctList = new List<ContentType>();
+            List<string> missingTypes = null;
+
+            foreach (var contentTypeName in x)
+            {
+                var ctName = contentTypeName.Trim();
+                var ct = ContentType.GetByName(ctName);
                 if (ct != null)
-                    ctList[i] = ct;
-			}
-            SetData(ctList);
+                {
+                    ctList.Add(ct);
+                }
+                else
+                {
+                    // allocate this list only if necessary
+                    if (missingTypes == null)
+                        missingTypes = new List<string>();
+
+                    missingTypes.Add(ctName);
+                }
+            }
+
+            if (missingTypes != null && missingTypes.Any())
+            {
+                SnLog.WriteWarning("Missing Content Types in an Allowed child types field.", 
+                    properties: new Dictionary<string, object>
+                    {
+                        { "Missing types: ", string.Join(", ", missingTypes.Distinct())},
+                        { "Content", this.Content.Path }
+                    });
+            }
+
+            SetData(ctList.ToArray());
             return true;
         }
 

--- a/src/ContentRepository/Schema/FieldSetting.cs
+++ b/src/ContentRepository/Schema/FieldSetting.cs
@@ -13,6 +13,7 @@ using LucField = Lucene.Net.Documents.Field;
 using SenseNet.Search;
 using SenseNet.Search.Indexing;
 using SenseNet.ContentRepository.Storage;
+using SenseNet.Diagnostics;
 using SenseNet.Tools;
 
 namespace SenseNet.ContentRepository.Schema
@@ -881,9 +882,16 @@ namespace SenseNet.ContentRepository.Schema
             var typeName = names.Length == 2 ? names[0] : string.Empty;
             fieldName = names.Length == 1 ? names[0] : names[1];
 
-            return (!string.IsNullOrEmpty(typeName) && !fieldName.StartsWith("#")) ?
-                ContentType.GetByName(typeName).GetFieldSettingByName(fieldName) :
-                null;
+            if (!string.IsNullOrEmpty(typeName) && !fieldName.StartsWith("#"))
+            {
+                var ct = ContentType.GetByName(typeName);
+                if (ct != null)
+                    return ct.GetFieldSettingByName(fieldName);
+
+                SnLog.WriteWarning($"Content type {typeName} not found when converting fullname {fullName} to a fieldsetting.");
+            }
+
+            return null;
         }
 
         public static FieldSetting GetRoot(FieldSetting fieldSetting)


### PR DESCRIPTION
**Behavior change**: logging warning messages silently, instead of throwing nullreference exceptions, when a content type is missing. This prevented some content to be saved (imported) or list grids to be displayed.

- Allowed child types field writes a meaningful warning when a desired allowed child type is missing, instead of allowing a _nullreference_ exception occur in a lower layer
- Fieldsetting also logs a warning silently if a column full name contains an unknown content type name


