### PR TITLE
Allow the hyphen character in SnAdmin parameter names.

### DIFF
--- a/src/ContentRepository/Packaging/PackageParameter.cs
+++ b/src/ContentRepository/Packaging/PackageParameter.cs
@@ -4,8 +4,8 @@ namespace SenseNet.Packaging
 {
     public class PackageParameter
     {
-        internal static readonly string ParameterRegex = @"^([\w_]+):";
-        
+        internal static readonly string ParameterRegex = @"^(([\w_]+[\-]{0,1})+):";
+
         public string PropertyName { get; private set; }
         public string Value { get; private set; }
 


### PR DESCRIPTION
Currently it is not possible to provide an SnAdmin parameter like the last one here:

```txt
snadmin install-workspaces install-demo:true
```

To make this possible, I changed the regex to accept hyphens in parameter names. 

>**Important**: the same change has to be made in SnAdmin (_Arguments_ class) to be effective. See this [related PR](https://github.com/SenseNet/sn-admin/pull/13).