### PR TITLE
FIX: Compare repo path ignoring the case in RepositoryFile

### DIFF
--- a/src/Services/Virtualization/RepositoryFile.cs
+++ b/src/Services/Virtualization/RepositoryFile.cs
@@ -148,8 +148,8 @@ namespace SenseNet.Portal.Virtualization
                     // at the end of the request (PortalContextModule.EndRequest method).
                     if (HttpContext.Current != null &&
                         PortalContext.Current != null &&
-                        PortalContext.Current.RepositoryPath == _repositoryPath &&
-                        (string.IsNullOrEmpty(PortalContext.Current.ActionName) || PortalContext.Current.ActionName == "Browse") &&
+                        string.Equals(PortalContext.Current.RepositoryPath, _repositoryPath, StringComparison.InvariantCultureIgnoreCase) &&
+                        (string.IsNullOrEmpty(PortalContext.Current.ActionName) || string.Equals(PortalContext.Current.ActionName, "Browse", StringComparison.InvariantCultureIgnoreCase)) &&
                         !string.IsNullOrEmpty(contentType) &&
                         contentType != "text/asp")
                     {


### PR DESCRIPTION
This way content type header is added correctly to the response, even if the path casing is incorrect.

(without this fix two path values were considered unequal, even if they were different only in their casing - e.g. _/Root/scripts/test.js_ and _/Root/Scripts/test.js_ - and the result was an **incorrect text/html content type header** in the response, instead of text/javascript)