### PR TITLE
Add CORS header and preflight response 

### DIFF
--- a/src/Services/OData/ODataHandler.cs
+++ b/src/Services/OData/ODataHandler.cs
@@ -221,11 +221,8 @@ namespace SenseNet.Portal.OData
                         }
                         break;
                     case "OPTIONS":
-                        // Prepare preflight response.
-                        // The header: Access-Control-Allow-Methods: GET, POST, PATCH, MERGE, PUT
-                        HttpHeaderTools.SetPreflightResponse(
-                            httpVerbs: new[] { "GET", "POST", "PATCH", "MERGE", "PUT" },
-                            httpHeaders: new[] { "X-Authentication-Type", "X-Refresh-Data", "X-Access-Data", "X-Requested-With", "Authorization", "Content-Type" });
+                        // set allowed methods and headers
+                        HttpHeaderTools.SetPreflightResponse();
                         break;
                 }
             }

--- a/src/Services/OData/ODataHandler.cs
+++ b/src/Services/OData/ODataHandler.cs
@@ -223,7 +223,9 @@ namespace SenseNet.Portal.OData
                     case "OPTIONS":
                         // Prepare preflight response.
                         // The header: Access-Control-Allow-Methods: GET, POST, PATCH, MERGE, PUT
-                        HttpHeaderTools.SetPreflightResponse("GET", "POST", "PATCH", "MERGE", "PUT");
+                        HttpHeaderTools.SetPreflightResponse(
+                            httpVerbs: new[] { "GET", "POST", "PATCH", "MERGE", "PUT" },
+                            httpHeaders: new[] { "X-Authentication-Type", "X-Refresh-Data", "X-Access-Data", "X-Requested-With", "Authorization", "Content-Type" });
                         break;
                 }
             }

--- a/src/Services/PortalSettings.cs
+++ b/src/Services/PortalSettings.cs
@@ -28,6 +28,8 @@ namespace SenseNet.Portal
         public const string SETTINGS_UPLOADFILEEXTENSIONS = "UploadFileExtensions";
         public const string SETTINGS_UPLOADFILEEXTENSIONS_DEFAULT = "UploadFileExtensions.DefaultContentType";
         public const string SETTINGS_ALLOWEDORIGINDOMAINS = "AllowedOriginDomains";
+        public const string SETTINGS_ALLOWEDMETHODS = "AllowedMethods";
+        public const string SETTINGS_ALLOWEDHEADERS = "AllowedHeaders";
 
         public PortalSettings(Node parent) : this(parent, null) { }
         public PortalSettings(Node parent, string nodeTypeName) : base(parent, nodeTypeName) {}

--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -18,6 +18,7 @@ namespace SenseNet.Portal.Virtualization
         private static readonly string HEADER_ACESSCONTROL_ALLOWORIGIN_NAME = "Access-Control-Allow-Origin";
         private static readonly string HEADER_ACESSCONTROL_ALLOWCREDENTIALS_NAME = "Access-Control-Allow-Credentials";
         private static readonly string ACCESS_CONTROL_ALLOW_METHODS_NAME = "Access-Control-Allow-Methods";
+        private static readonly string ACCESS_CONTROL_ALLOW_HEADERS_NAME = "Access-Control-Allow-Headers";
         private static readonly string HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL = "*";
         private static readonly string HEADER_ACESSCONTROL_ORIGIN_NAME = "Origin";
 
@@ -243,11 +244,14 @@ namespace SenseNet.Portal.Virtualization
         /// Sets the Access-Control-Allow-Methods header that is a response to the OData OPTIONS request.
         /// </summary>
         /// <param name="httpVerbs">List of the allowed HTTP verbs. For example: "GET", "POST". Cannot be null.</param>
-        public static void SetPreflightResponse(params string[] httpVerbs)
+        /// <param name="httpHeaders">List of the allowed HTTP headers. For example: "Content-Type", "Authentication". Cannot be null.</param>
+        public static void SetPreflightResponse(string[] httpVerbs, string[] httpHeaders)
         {
             if(httpVerbs == null)
                 throw new ArgumentNullException(nameof(httpVerbs));
             HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_METHODS_NAME, string.Join(", ", httpVerbs));
+
+            HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_HEADERS_NAME, string.Join(", ", httpHeaders));
         }
 
         /// <summary>

--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -22,6 +22,17 @@ namespace SenseNet.Portal.Virtualization
         private static readonly string HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL = "*";
         private static readonly string HEADER_ACESSCONTROL_ORIGIN_NAME = "Origin";
 
+        private static readonly string[] ACCESS_CONTROL_ALLOW_METHODS_DEFAULT =
+        {
+            "GET", "POST", "PATCH", "DELETE", "MERGE", "PUT"
+        };
+        private static readonly string[] ACCESS_CONTROL_ALLOW_HEADERS_DEFAULT =
+        {
+            "X-Authentication-Type",
+            "X-Refresh-Data", "X-Access-Data",
+            "X-Requested-With", "Authorization", "Content-Type"
+        };
+
         private delegate void PurgeDelegate(IEnumerable<string> urls);
 
 
@@ -241,17 +252,24 @@ namespace SenseNet.Portal.Virtualization
         }
 
         /// <summary>
-        /// Sets the Access-Control-Allow-Methods header that is a response to the OData OPTIONS request.
+        /// Sets the Access-Control-Allow-Methods and Access-Control-Allow-Headers headers 
+        /// in a response of an OPTIONS request.
         /// </summary>
-        /// <param name="httpVerbs">List of the allowed HTTP verbs. For example: "GET", "POST". Cannot be null.</param>
-        /// <param name="httpHeaders">List of the allowed HTTP headers. For example: "Content-Type", "Authentication". Cannot be null.</param>
-        public static void SetPreflightResponse(string[] httpVerbs, string[] httpHeaders)
+        /// <param name="httpVerbs">List of the allowed HTTP verbs. For example: "GET", "POST". 
+        /// If set to null, a global setting is used.</param>
+        /// <param name="httpHeaders">List of the allowed HTTP headers. For example: "Content-Type", "Authentication". 
+        /// If set to null, a global setting is used.</param>
+        public static void SetPreflightResponse(string[] httpVerbs = null, string[] httpHeaders = null)
         {
-            if(httpVerbs == null)
-                throw new ArgumentNullException(nameof(httpVerbs));
-            HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_METHODS_NAME, string.Join(", ", httpVerbs));
+            HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_METHODS_NAME, string.Join(", ", 
+                httpVerbs ?? Settings.GetValue(PortalSettings.SETTINGSNAME,
+                PortalSettings.SETTINGS_ALLOWEDMETHODS, null,
+                ACCESS_CONTROL_ALLOW_METHODS_DEFAULT)));
 
-            HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_HEADERS_NAME, string.Join(", ", httpHeaders));
+            HttpContext.Current.Response.Headers.Set(ACCESS_CONTROL_ALLOW_HEADERS_NAME, string.Join(", ", 
+                httpHeaders ?? Settings.GetValue(PortalSettings.SETTINGSNAME, 
+                PortalSettings.SETTINGS_ALLOWEDHEADERS, null, 
+                ACCESS_CONTROL_ALLOW_HEADERS_DEFAULT)));
         }
 
         /// <summary>

--- a/src/Services/Virtualization/PortalAuthenticationModule.cs
+++ b/src/Services/Virtualization/PortalAuthenticationModule.cs
@@ -133,6 +133,17 @@ namespace SenseNet.Portal.Virtualization
 
             if (IsTokenAuthenticationRequested(request))
             {
+                // Cross-Origin Resource Sharing (CORS)
+                if (!HttpHeaderTools.IsOriginHeaderAllowed())
+                    AuthenticationHelper.ThrowForbidden("token auth");
+
+                if (request?.HttpMethod == "OPTIONS")
+                {
+                    // Prepare preflight response.
+                    // The header: Access-Control-Allow-Methods: GET, POST, PATCH, MERGE, PUT
+                    HttpHeaderTools.SetPreflightResponse("GET", "POST", "PATCH", "MERGE", "PUT");
+                }
+
                 if (basicAuthenticated && anonymAuthenticated)
                 {
                     SnLog.WriteException(new UnauthorizedAccessException("Invalid user."));

--- a/src/Services/Virtualization/PortalAuthenticationModule.cs
+++ b/src/Services/Virtualization/PortalAuthenticationModule.cs
@@ -141,7 +141,11 @@ namespace SenseNet.Portal.Virtualization
                 {
                     // Prepare preflight response.
                     // The header: Access-Control-Allow-Methods: GET, POST, PATCH, MERGE, PUT
-                    HttpHeaderTools.SetPreflightResponse("GET", "POST", "PATCH", "MERGE", "PUT");
+                    HttpHeaderTools.SetPreflightResponse(
+                            httpVerbs: new [] {"GET", "POST", "PATCH", "MERGE", "PUT"}, 
+                            httpHeaders: new [] { "X-Authentication-Type", "X-Refresh-Data", "X-Access-Data", "X-Requested-With", "Authorization", "Content-Type" });
+
+                    application?.CompleteRequest();
                 }
 
                 if (basicAuthenticated && anonymAuthenticated)

--- a/src/Services/Virtualization/PortalAuthenticationModule.cs
+++ b/src/Services/Virtualization/PortalAuthenticationModule.cs
@@ -139,11 +139,8 @@ namespace SenseNet.Portal.Virtualization
 
                 if (request?.HttpMethod == "OPTIONS")
                 {
-                    // Prepare preflight response.
-                    // The header: Access-Control-Allow-Methods: GET, POST, PATCH, MERGE, PUT
-                    HttpHeaderTools.SetPreflightResponse(
-                            httpVerbs: new [] {"GET", "POST", "PATCH", "MERGE", "PUT"}, 
-                            httpHeaders: new [] { "X-Authentication-Type", "X-Refresh-Data", "X-Access-Data", "X-Requested-With", "Authorization", "Content-Type" });
+                    // set allowed methods and headers
+                    HttpHeaderTools.SetPreflightResponse();
 
                     application?.CompleteRequest();
                 }


### PR DESCRIPTION
In case of a **JWT token auth request**, the same CORS and preflight headers should be added to the response as in case of an **OData request**, so that **JWT auth works with CORS**.