### PR TITLE
Feature/snadmin setfield

### DIFF
--- a/docs/snadmin-builtin-steps.md
+++ b/docs/snadmin-builtin-steps.md
@@ -232,6 +232,70 @@ If the “import” directory contains a content “MyContent”, after the exec
 ### ImportSchema
 >This step is deprecated, use the more generic **Import** step to import all kinds of content, even content types to the repository.
 
+### SetField
+- Full name: `SenseNet.Packaging.Steps.SetField`
+- Default property: `Value`
+- Additional properties: `Content, Name, Fields, Overwrite`
+
+> This step can be placed in ForEach steps' Block sections.
+
+Sets one or more field values on the provided content. By default the field values will be overwritten unconditionally, but if you set the *overwrite* property to false, fields that already contain a value will be skipped.
+
+```xml
+<SetField name="Description" content="/Root/MyContent"><![CDATA[New description]]></SetField>
+
+<SetField name="IncomingEmailWorkflow" content="/Root/ContentTemplates/DocumentLibrary/Document_Library" overwrite="@overwrite">
+   <Value>
+      <Path>/Root/System/Schema/ContentTypes/GenericContent/Workflow/MailProcessorWorkflow</Path>
+   </Value>
+</SetField>
+
+<SetField content="/Root/ContentTemplates/EventList/Calendar" overwrite="@overwrite">
+   <Fields>
+      <Field name="IncomingEmailWorkflow">
+         <Value>
+            <Path>/Root/System/Schema/ContentTypes/GenericContent/Workflow/MailProcessorWorkflow</Path>
+         </Value>
+      </Field>
+   </Fields>   	
+</SetField>
+```
+
+### AddReference
+- Full name: `SenseNet.Packaging.Steps.AddReference`
+- Default property: -
+- Additional properties: `Content, Name, Value, Fields`
+
+> This step can be placed in ForEach steps' Block sections.
+
+Adds one or more content as a reference to a reference field. Previous list is preserved, this is an addition. Both path and id work.
+
+```xml
+<AddReference name="Members" content="/Root/IMS/BuiltIn/Portal/HR">
+   <Value>
+      <Path>/Root/IMS/BuiltIn/johnsmiths</Path>
+      <Id>12345</Id>
+   </Value>
+</AddReference>
+```
+
+### RemoveReference
+- Full name: `SenseNet.Packaging.Steps.RemoveReference`
+- Default property: -
+- Additional properties: `Content, Name, Value, Fields`
+
+> This step can be placed in ForEach steps' Block sections.
+
+Removes one or more content from a reference field. All other referenced values remain untouched. Both path and id work.
+
+```xml
+<RemoveReference name="Members" content="/Root/IMS/BuiltIn/Portal/HR">
+   <Value>
+      <Path>/Root/IMS/BuiltIn/johnsmiths</Path>
+   </Value>
+</RemoveReference>
+```
+
 ### Rename
 -   Full name: `SenseNet.Packaging.Steps.Rename`
 -   Default property: `NewName`

--- a/src/ContentRepository/ContentRepository.csproj
+++ b/src/ContentRepository/ContentRepository.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Packaging\SR.cs" />
     <Compile Include="Packaging\Steps\AddField.cs" />
     <Compile Include="Packaging\Steps\AddMembers.cs" />
+    <Compile Include="Packaging\Steps\RemoveReference.cs" />
+    <Compile Include="Packaging\Steps\AddReference.cs" />
     <Compile Include="Packaging\Steps\AddResource.cs" />
     <Compile Include="Packaging\Steps\IfComponentExists.cs" />
     <Compile Include="Packaging\Steps\IfMatch.cs" />

--- a/src/ContentRepository/ContentRepository.csproj
+++ b/src/ContentRepository/ContentRepository.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Packaging\Steps\PopulateIndex.cs" />
     <Compile Include="Packaging\Steps\Rename.cs" />
     <Compile Include="Packaging\Steps\ReplaceText.cs" />
+    <Compile Include="Packaging\Steps\SetField.cs" />
     <Compile Include="Packaging\Steps\SetPermissions.cs" />
     <Compile Include="Packaging\Steps\StartRepository.cs" />
     <Compile Include="Packaging\Steps\Step.cs" />

--- a/src/ContentRepository/Fields/ReferenceField.cs
+++ b/src/ContentRepository/Fields/ReferenceField.cs
@@ -290,6 +290,20 @@ namespace SenseNet.ContentRepository.Fields
 
         }
 
+        public override bool HasValue()
+        {
+            var originalValue = OriginalValue;
+            if (originalValue == null)
+                return false;
+
+            var node = originalValue as Node;
+            if (node != null)
+                return true;
+
+            var nodes = originalValue as IEnumerable;
+            return nodes != null && nodes.Cast<Node>().Any();
+        }
+
         /*======================================================= IXmlChildList Members ====*/
 
         public string GetXmlChildName()

--- a/src/ContentRepository/Packaging/Steps/AddReference.cs
+++ b/src/ContentRepository/Packaging/Steps/AddReference.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Fields;
+using SenseNet.ContentRepository.Storage;
+
+namespace SenseNet.Packaging.Steps
+{
+    public class AddReference : SetField
+    {
+        public override void Execute(ExecutionContext context)
+        {
+            context.AssertRepositoryStarted();
+
+            Content content;
+            Dictionary<string, string> fieldValues;
+            bool overwrite;
+
+            ParseParameters(context, out content, out fieldValues, out overwrite);
+
+            Logger.LogMessage($"Updating: {content.Path}");
+
+            var xDoc = GetFieldXmlDocument(fieldValues);
+            var node = content.ContentHandler;
+
+            foreach (var fieldName in fieldValues.Keys)
+            {
+                var fieldNode = xDoc.DocumentElement.SelectSingleNode($"//{fieldName}");
+
+                if (!(content.Fields[fieldName] is ReferenceField))
+                    throw new InvalidStepParameterException($"{fieldName} is not a reference field.");
+
+                var references = fieldNode.ChildNodes.Cast<XmlNode>()
+                    .Select(x => Node.LoadNodeByIdOrPath(x.InnerText.Trim())).Where(n => n != null);
+
+                node.AddReferences(fieldName, references);
+            }
+
+            // wrap the node into a content just to make saving the same version easier
+            var editedContent = ContentRepository.Content.Create(node);
+            editedContent.SaveSameVersion();
+        }
+    }
+}

--- a/src/ContentRepository/Packaging/Steps/RemoveReference.cs
+++ b/src/ContentRepository/Packaging/Steps/RemoveReference.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Fields;
+using SenseNet.ContentRepository.Storage;
+
+namespace SenseNet.Packaging.Steps
+{
+    public class RemoveReference : SetField
+    {
+        public override void Execute(ExecutionContext context)
+        {
+            context.AssertRepositoryStarted();
+
+            Content content;
+            Dictionary<string, string> fieldValues;
+            bool overwrite;
+
+            ParseParameters(context, out content, out fieldValues, out overwrite);
+
+            Logger.LogMessage($"Updating: {content.Path}");
+
+            var xDoc = GetFieldXmlDocument(fieldValues);
+            var node = content.ContentHandler;
+
+            foreach (var fieldName in fieldValues.Keys)
+            {
+                var fieldNode = xDoc.DocumentElement.SelectSingleNode($"//{fieldName}");
+
+                if (!(content.Fields[fieldName] is ReferenceField))
+                    throw new InvalidStepParameterException($"{fieldName} is not a reference field.");
+
+                var references = fieldNode.ChildNodes.Cast<XmlNode>()
+                    .Select(x => Node.LoadNodeByIdOrPath(x.InnerText.Trim())).Where(n => n != null);
+
+                foreach (var reference in references)
+                {
+                    node.RemoveReference(fieldName, reference);
+                }
+            }
+
+            // wrap the node into a content just to make saving the same version easier
+            var editedContent = ContentRepository.Content.Create(node);
+            editedContent.SaveSameVersion();
+        }
+    }
+}

--- a/src/ContentRepository/Packaging/Steps/SetField.cs
+++ b/src/ContentRepository/Packaging/Steps/SetField.cs
@@ -36,13 +36,12 @@ namespace SenseNet.Packaging.Steps
             bool overwrite;
 
             ParseParameters(context, out content, out fieldValues, out overwrite);
-
-            Logger.LogMessage($"Updating: {content.Path}");
-
+            
             var xDoc = GetFieldXmlDocument(fieldValues);
             
             // ReSharper disable once PossibleNullReferenceException
             var importContext = new ImportContext(xDoc.DocumentElement.ChildNodes, null, false, true, true);
+            var changed = false;
 
             foreach (var fieldName in fieldValues.Keys)
             {
@@ -51,9 +50,19 @@ namespace SenseNet.Packaging.Steps
 
                 var fieldNode = xDoc.DocumentElement.SelectSingleNode($"//{fieldName}");
                 content.Fields[fieldName].Import(fieldNode, importContext);
+
+                changed = true;
             }
-            
-            content.SaveSameVersion();
+
+            if (changed)
+            {
+                Logger.LogMessage($"Updating: {content.Path}");
+                content.SaveSameVersion();
+            }
+            else
+            {
+                Logger.LogMessage($"SKIPPED: {content.Path}");
+            }
         }
 
         protected void ParseParameters(ExecutionContext context, 

--- a/src/ContentRepository/Packaging/Steps/SetField.cs
+++ b/src/ContentRepository/Packaging/Steps/SetField.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Storage;
+
+namespace SenseNet.Packaging.Steps
+{
+    /// <summary>
+    /// Modifies a value of one or more fields on a content.
+    /// </summary>
+    public class SetField : Step
+    {
+        [Annotation("Repository path of the content to be edited.")]
+        public string Content { get; set; }
+        [Annotation("Name of the field to be set.")]
+        public string Name { get; set; }
+
+        [Annotation("List of field values to be set.")]
+        public string Fields { get; set; }
+
+        [DefaultProperty]
+        [Annotation("Field value in the same format as in the import .Content files.")]
+        public string Value { get; set; }
+
+        [Annotation("Whether the field should be overwritten if not empty. Default: true")]
+        public string Overwrite { get; set; }
+
+        public override void Execute(ExecutionContext context)
+        {
+            context.AssertRepositoryStarted();
+
+            Content content;
+            Dictionary<string, string> fieldValues;
+            bool overwrite;
+
+            ParseParameters(context, out content, out fieldValues, out overwrite);
+
+            Logger.LogMessage($"Updating: {content.Path}");
+
+            var xDoc = GetFieldXmlDocument(fieldValues);
+            
+            // ReSharper disable once PossibleNullReferenceException
+            var importContext = new ImportContext(xDoc.DocumentElement.ChildNodes, null, false, true, true);
+
+            foreach (var fieldName in fieldValues.Keys)
+            {
+                if (!overwrite && content.Fields[fieldName].HasValue())
+                    continue;
+
+                var fieldNode = xDoc.DocumentElement.SelectSingleNode($"//{fieldName}");
+                content.Fields[fieldName].Import(fieldNode, importContext);
+            }
+            
+            content.SaveSameVersion();
+        }
+
+        protected void ParseParameters(ExecutionContext context, 
+            out Content content, 
+            out Dictionary<string, string> fieldValues, 
+            out bool overwrite)
+        {
+            if (string.IsNullOrEmpty(Content))
+                throw new PackagingException(SR.Errors.InvalidParameters);
+            
+            var path = context.ResolveVariable(Content) as string;
+            if (RepositoryPath.IsValidPath(path) != RepositoryPath.PathResult.Correct)
+                throw new PackagingException(SR.Errors.InvalidParameters);
+
+            content = ContentRepository.Content.Load(path);
+            if (content == null)
+                throw new PackagingException("Content not found: " + path);
+
+            fieldValues = new Dictionary<string, string>();
+
+            // either Field or Fields should be filled, but not both
+            if ((string.IsNullOrEmpty(Name) && string.IsNullOrEmpty(Fields)) ||
+                (!string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(Fields)))
+                throw new PackagingException(SR.Errors.InvalidParameters);
+
+            if (!string.IsNullOrEmpty(Name))
+            {
+                // simple syntax, single field definition
+                var fieldName = context.ResolveVariable(Name) as string;
+                if (string.IsNullOrEmpty(fieldName) || !content.Fields.ContainsKey(fieldName))
+                    throw new PackagingException($"Field '{fieldName}' not found on content {path}");
+
+                fieldValues[fieldName] = context.ResolveVariable(Value) as string;
+            }
+            else
+            {
+                // complex syntax, multiple field values are provided
+                var xDoc = new XmlDocument();
+                xDoc.LoadXml($"<Fields>{context.ResolveVariable(Fields) as string}</Fields>");
+
+                if (xDoc.DocumentElement != null)
+                {
+                    foreach (XmlNode fieldNode in xDoc.DocumentElement.ChildNodes)
+                    {
+                        var fieldName = fieldNode?.Attributes?["name"]?.Value;
+                        if (string.IsNullOrEmpty(fieldName))
+                            throw new InvalidStepParameterException("Field name is missing.");
+
+                        if (!content.Fields.ContainsKey(fieldName))
+                            throw new InvalidStepParameterException(
+                                $"Content {content.Path} does not have a field with the name {fieldName}.");
+
+                        if (fieldNode.FirstChild == null || fieldNode.ChildNodes.Count > 1)
+                            throw new InvalidStepParameterException("Incorrect field xml definition.");
+
+                        fieldValues[fieldName] = fieldNode.FirstChild.InnerXml;
+                    }
+                }
+            }
+
+            overwrite = ParseOverWrite(context);
+        }
+
+        protected bool ParseOverWrite(ExecutionContext context)
+        {
+            var overwrite = true;
+            var overwriteValue = context.ResolveVariable(Overwrite);
+
+            if (overwriteValue is bool)
+            {
+                overwrite = (bool)overwriteValue;
+            }
+            else
+            {
+                var overwriteText = overwriteValue as string;
+
+                if (!string.IsNullOrEmpty(overwriteText))
+                {
+                    bool result;
+                    if (bool.TryParse(overwriteText, out result))
+                        overwrite = result;
+                    else
+                        throw new InvalidParameterException("Value could not be converted to bool: " + overwriteText);
+                }
+            }
+
+            return overwrite;
+        }
+
+        /// <summary>
+        /// Constructs an xml document from field values in a format that is recognised by the import API.
+        /// </summary>
+        protected XmlDocument GetFieldXmlDocument(Dictionary<string, string> fieldValues)
+        {
+            // load the values in a fake xml document
+            var xDoc = new XmlDocument();
+            xDoc.LoadXml($"<Fields>{string.Join(Environment.NewLine, fieldValues.Select(f => $"<{f.Key}>{f.Value}</{f.Key}>"))}</Fields>");
+
+            if (xDoc.DocumentElement == null)
+                throw new PackagingException("Invalid field value xml.");
+
+            return xDoc;
+        }
+    }
+}

--- a/src/ContentRepository/Packaging/Steps/SetField.cs
+++ b/src/ContentRepository/Packaging/Steps/SetField.cs
@@ -123,10 +123,10 @@ namespace SenseNet.Packaging.Steps
                 }
             }
 
-            overwrite = ParseOverWrite(context);
+            overwrite = ParseOverwrite(context);
         }
 
-        protected bool ParseOverWrite(ExecutionContext context)
+        protected bool ParseOverwrite(ExecutionContext context)
         {
             var overwrite = true;
             var overwriteValue = context.ResolveVariable(Overwrite);


### PR DESCRIPTION
Add new packaging steps (see included doc changes for details):
- SetField
- AddReference
- RemoveReference

+1: Reference field has a correctly implemented HasValue method that returns with **true** only if there are elements in the collection.

These features were necessary for the _Workflow_ component, because its installer package has to set the _Incoming email workflow_ field on existing content lists, and this could not be done using the existing _Import_ step.