### PR TITLE
Load types without throwing an error

### DIFF
--- a/src/ContentRepository/ContentList.cs
+++ b/src/ContentRepository/ContentList.cs
@@ -1073,12 +1073,12 @@ namespace SenseNet.ContentRepository
             }
 
             // reflection: because we do not have access to the workflow engine here
-            var t = TypeResolver.GetType("SenseNet.Workflow.InstanceManager");
-            if (t != null)
-            {
-                var m = t.GetMethod("Start", BindingFlags.Static | BindingFlags.Public);
-                m.Invoke(null, new object[] { workflowC.ContentHandler });
-            }
+            var t = TypeResolver.GetType("SenseNet.Workflow.InstanceManager", false);
+            if (t == null)
+                return;
+
+            var m = t.GetMethod("Start", BindingFlags.Static | BindingFlags.Public);
+            m.Invoke(null, new object[] { workflowC.ContentHandler });
         }
 
         private static Node GetMailProcessorWorkflowContainer(Node contextNode)

--- a/src/ContentRepository/ContentTemplate.cs
+++ b/src/ContentRepository/ContentTemplate.cs
@@ -526,8 +526,8 @@ namespace SenseNet.ContentRepository
 
                     content.ContentHandler.NodeOperation = NodeOperation.TemplateCreation;
                     content.ContentHandler.DisableObserver(typeof(DocumentPreviewObserver));
-                    content.ContentHandler.DisableObserver(TypeResolver.GetType(WFOBSERVERNAME));
-                    content.ContentHandler.DisableObserver(TypeResolver.GetType(NOTIFOBSERVERNAME));
+                    content.ContentHandler.DisableObserver(TypeResolver.GetType(WFOBSERVERNAME, false));
+                    content.ContentHandler.DisableObserver(TypeResolver.GetType(NOTIFOBSERVERNAME, false));
 
                     content.SaveSameVersion();
                 }

--- a/src/ContentRepository/GenericContent.cs
+++ b/src/ContentRepository/GenericContent.cs
@@ -1311,7 +1311,7 @@ namespace SenseNet.ContentRepository
         public void KeepWorkflowsAlive()
         {
             _keepWorkflowsAlive = true;
-            DisableObserver(TypeResolver.GetType(NodeObserverNames.WORKFLOWNOTIFICATION));
+            DisableObserver(TypeResolver.GetType(NodeObserverNames.WORKFLOWNOTIFICATION, false));
         }
 
         private void UpdateRelatedWorkflows()

--- a/src/ContentRepository/Schema/ContentType.cs
+++ b/src/ContentRepository/Schema/ContentType.cs
@@ -824,9 +824,9 @@ namespace  SenseNet.ContentRepository.Schema
         {
             if (fieldDesc.Analyzer != null)
             {
-                var analyzerType = TypeResolver.GetType(fieldDesc.Analyzer);
+                var analyzerType = TypeResolver.GetType(fieldDesc.Analyzer, false);
                 if (analyzerType == null)
-                    throw new RegistrationException(String.Concat("Unknown analyzer: ", fieldDesc.Analyzer, ". Field: ", fieldDesc.FieldName, ", ContentType: ", contentTypeName));
+                    throw new RegistrationException(string.Concat("Unknown analyzer: ", fieldDesc.Analyzer, ". Field: ", fieldDesc.FieldName, ", ContentType: ", contentTypeName));
             }
         }
         // ==================================================== IFolder 

--- a/src/ContentRepository/Schema/ContentTypeInstaller.cs
+++ b/src/ContentRepository/Schema/ContentTypeInstaller.cs
@@ -1,14 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using SenseNet.ContentRepository.Storage;
 using SenseNet.ContentRepository.Storage.Events;
 using SenseNet.ContentRepository.Storage.Schema;
 using System.IO;
 using System.Xml.XPath;
-using System.Diagnostics;
 using SenseNet.Configuration;
-using SenseNet.ContentRepository.Storage.Data;
 using SenseNet.Tools;
 
 namespace SenseNet.ContentRepository.Schema
@@ -116,12 +112,10 @@ namespace SenseNet.ContentRepository.Schema
 
         private void Install(CTD ctd)
         {
-            ContentType contentType = ContentTypeManager.LoadOrCreateNew(ctd.Document);
+            var contentType = ContentTypeManager.LoadOrCreateNew(ctd.Document);
 
             // skip notification during content type install to avoid missing field errors
-            var notificationObserver = TypeResolver.GetType(NodeObserverNames.NOTIFICATION, false);
-            if (notificationObserver != null)
-                contentType.DisableObserver(notificationObserver);
+            contentType.DisableObserver(TypeResolver.GetType(NodeObserverNames.NOTIFICATION, false));
 
             ContentTypeManager.ApplyChangesInEditor(contentType, _editor);
             contentType.Save(false);

--- a/src/ContentRepository/Schema/ContentTypeManager.cs
+++ b/src/ContentRepository/Schema/ContentTypeManager.cs
@@ -331,9 +331,9 @@ namespace SenseNet.ContentRepository.Schema
         internal static void ApplyChangesInEditor(ContentType contentType, SchemaEditor editor)
         {
             // Find ContentHandler
-            Type handlerType = TypeResolver.GetType(contentType.HandlerName);
+            var handlerType = TypeResolver.GetType(contentType.HandlerName, false);
             if (handlerType == null)
-                throw new RegistrationException(String.Concat(
+                throw new RegistrationException(string.Concat(
                     SR.Exceptions.Registration.Msg_ContentHandlerNotFound, ": ", contentType.HandlerName));
 
             // parent type

--- a/src/Services/OData/Parser/ExpressionBuilder.cs
+++ b/src/Services/OData/Parser/ExpressionBuilder.cs
@@ -91,8 +91,8 @@ namespace SenseNet.Portal.OData.Parser
             int k;
             if (steps[0].Contains('.'))
             {
-                type = TypeResolver.GetType(steps[0]);
-                if(type == null)
+                type = TypeResolver.GetType(steps[0], false);
+                if (type == null)
                     throw ODataParser.SyntaxError(this.Parser.Lexer, "Unknown type: " + steps[0]);
                 k = 1;
             }

--- a/src/Storage/DistributedApplication.cs
+++ b/src/Storage/DistributedApplication.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Configuration;
-using System.Web;
-using System.Diagnostics;
 using SenseNet.ContentRepository.Storage.Caching;
 using SenseNet.Communication.Messaging;
 using SenseNet.Configuration;
@@ -76,9 +71,9 @@ namespace SenseNet.ContentRepository
 
         private static Type GetChannelProviderType()
         {
-            var channelAdapterType = TypeResolver.GetType(Providers.ClusterChannelProviderClassName);
+            var channelAdapterType = TypeResolver.GetType(Providers.ClusterChannelProviderClassName, false);
             if (channelAdapterType == null)
-                throw new ArgumentException("ClusterChannelProvider is not correctly configured.");
+                throw new ArgumentException("ClusterChannelProvider is not configured correctly.");
 
             return channelAdapterType;
         }

--- a/src/Storage/Schema/NodeType.cs
+++ b/src/Storage/Schema/NodeType.cs
@@ -226,14 +226,14 @@ namespace SenseNet.ContentRepository.Storage.Schema
         public Node CreateInstance(Node parent)
         {
             if (parent == null)
-                throw new ArgumentNullException("parent");
+                throw new ArgumentNullException(nameof(parent));
 
             if (_type == null)
-                _type = TypeResolver.GetType(_className);
+                _type = TypeResolver.GetType(_className, false);
 
             if (_type == null)
             {
-                string exceptionMessage = String.Concat("Type not found, therefore the node can't be created.",
+                var exceptionMessage = string.Concat("Type not found, therefore the node can't be created.",
                     "\nClass name: ", _className,
                     "\nNode type path: ", _nodeTypePath,
                     "\nParent class name: ", (_parent != null ? _parent._className : "Parent is null"), "\n");
@@ -243,7 +243,7 @@ namespace SenseNet.ContentRepository.Storage.Schema
             // only public ctor is valid: public NodeDescendant(Node parent, string nodeTypeName)
             ConstructorInfo ctor = _type.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, _newArgTypes, null);
             if (ctor == null)
-                throw new TypeInitializationException(String.Concat("Constructor not found. Valid signature: ctor(Node, string).\nClassName: ", _className), null);
+                throw new TypeInitializationException(string.Concat("Constructor not found. Valid signature: ctor(Node, string).\nClassName: ", _className), null);
 
             Node node;
             try
@@ -262,11 +262,11 @@ namespace SenseNet.ContentRepository.Storage.Schema
         internal Node CreateInstance(NodeToken token)
         {
             if (_type == null)
-                _type = TypeResolver.GetType(_className);
+                _type = TypeResolver.GetType(_className, false);
 
             if (_type == null)
             {
-                string exceptionMessage = string.Format(CultureInfo.InvariantCulture, "Type not found, therefore the node can't be created.\nClass name: {0}\nNode type path: {1}\nParent class name: {2}\n", _className, _nodeTypePath, (_parent != null ? _parent._className : "Parent type is null"));
+                var exceptionMessage = string.Format(CultureInfo.InvariantCulture, "Type not found, therefore the node can't be created.\nClass name: {0}\nNode type path: {1}\nParent class name: {2}\n", _className, _nodeTypePath, (_parent != null ? _parent._className : "Parent type is null"));
                 if (token != null)
                     exceptionMessage = string.Concat(exceptionMessage, string.Format(CultureInfo.InvariantCulture, "Token.NodeId: {0}\nToken.Path: {1}", token.NodeId, (token.NodeData != null ? token.NodeData.Path : "UNKNOWN (InnerInfo is not loaded)")));
                 else

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -1668,7 +1668,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         private static Type GetMessageProviderType()
         {
             var messageProviderTypeName = Providers.SecurityMessageProviderClassName;
-            var t = TypeResolver.GetType(messageProviderTypeName);
+            var t = TypeResolver.GetType(messageProviderTypeName, false);
             if (t == null)
                 throw new InvalidOperationException("Unknown security message provider: " + messageProviderTypeName);
 


### PR DESCRIPTION
Throw an error only after, if necessary.
The indicator of this fix was a bug in templated content creation (see [related issue](https://github.com/sensenet/sensenet/issues/135)).

(note: the commit contains a few small refactors as usual, sorry)