### PR TITLE
Suppress field errors when serving a content through odata.

### DIFF
--- a/src/Services/OData/ODataFormatter.cs
+++ b/src/Services/OData/ODataFormatter.cs
@@ -869,7 +869,19 @@ new StackInfo
             {
                 return ODataReference.Create(String.Concat(selfUrl, "/", field.Name));
             }
-            data = field.GetData();
+            try
+            {
+                data = field.GetData();
+            }
+            catch (SenseNetSecurityException)
+            {
+                // The user does not have access to this field (e.g. cannot load
+                // a referenced content). In this case we serve a null value.
+                data = null;
+
+                SnTrace.Repository.Write("PERMISSION warning: user {0} does not have access to field '{1}' of {2}.", User.LoggedInUser.Username, field.Name, field.Content.Path);
+            }
+
             var nodeType = data as NodeType;
             if (nodeType != null)
                 return nodeType.Name;


### PR DESCRIPTION
This change makes odata responses more robust.

If an _odata operation_ returns a content to the _odata formatter_, we go through its fields one by one and format them as a json value. If a security error occurs during formatting a field (e.g. a field tries to access another content that the user does not have access to), it makes the whole response invalid by returning an error code. This change suppresses that exception and silently returns a **null value**.

Example: after registering a user we want to return the new user content, but the current user (still a Visitor) does not have access to the _Profile_ of the newly created user.