### PR TITLE
Default enabled CORS headers

### DIFF
--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -30,7 +30,8 @@ namespace SenseNet.Portal.Virtualization
         {
             "X-Authentication-Type",
             "X-Refresh-Data", "X-Access-Data",
-            "X-Requested-With", "Authorization", "Content-Type"
+            "X-Requested-With", "Authorization", "Content-Type",
+            "Content-Range", "Content-Disposition"
         };
 
         private delegate void PurgeDelegate(IEnumerable<string> urls);


### PR DESCRIPTION
"Content-Range" and "Content-Disposition" headers are used by the built-in Upload action, so I added them to the default enabled list.