### PR TITLE
Replace templates in SnExpression before parsing query text

### DIFF
--- a/src/ContentRepository/Linq/SnExpression.cs
+++ b/src/ContentRepository/Linq/SnExpression.cs
@@ -53,7 +53,9 @@ namespace SenseNet.ContentRepository.Linq
             SnQuery lq = null;
             if (!string.IsNullOrEmpty(childrenDef?.ContentQuery))
             {
-                lq = SnQuery.Parse(childrenDef.ContentQuery, new SnQueryContext(QuerySettings.Default, User.Current.Id));
+                var queryText = TemplateManager.Replace(typeof(ContentQueryTemplateReplacer), childrenDef.ContentQuery);
+
+                lq = SnQuery.Parse(queryText, new SnQueryContext(QuerySettings.Default, User.Current.Id));
                 q0 = q0 == null 
                     ? lq.QueryTree 
                     : CombineQueries(q0, lq.QueryTree);

--- a/src/Tests/SenseNet.ContentRepository.Tests/LinqTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/LinqTests.cs
@@ -856,6 +856,26 @@ namespace SenseNet.ContentRepository.Tests
         }
 
         [TestMethod, TestCategory("IR, LINQ")]
+        public void Linq_ReplaceTemplates()
+        {
+            Test(() =>
+            {
+                var childrenDef = new ChildrenDefinition
+                {
+                    PathUsage = PathUsageMode.InFolderOr,
+                    ContentQuery = "CreationDate:<@@CurrentDay@@"
+                };
+                var expr = Content.All.Where(c => c.IsFolder == true).Expression;
+                var actual = SnExpression.BuildQuery(expr, typeof(Content), "/Root/FakePath", childrenDef).ToString();
+                var expected = $"(+IsFolder:yes +CreationDate:<'{DateTime.UtcNow.Date:yyyy-MM-dd} 00:00:00.0000') InFolder:/root/fakepath";
+
+                Assert.AreEqual(expected, actual);
+
+                return true;
+            });
+        }
+
+        [TestMethod, TestCategory("IR, LINQ")]
         public void Linq_API()
         {
             Test(() =>


### PR DESCRIPTION
Replace templates in SnExpression before parsing query text **provided in children definition**.