### PR TITLE
Dealing with API changes during patching

### DIFF
--- a/src/ContentRepository/ContentRepository.csproj
+++ b/src/ContentRepository/ContentRepository.csproj
@@ -163,6 +163,8 @@
     <Compile Include="Configuration\Services.cs" />
     <Compile Include="Configuration\Versioning.cs" />
     <Compile Include="ISnComponent.cs" />
+    <Compile Include="Packaging\Steps\Internal\CopyCustomAssemblies.cs" />
+    <Compile Include="Packaging\Steps\Internal\ImportCustomContent.cs" />
     <Compile Include="Search\Indexing\NullPopulator.cs" />
     <Compile Include="SnComponent.cs" />
     <Compile Include="Linq\CaseInsensitiveFilterVisitor.cs" />

--- a/src/ContentRepository/Packaging/Steps/Internal/CopyCustomAssemblies.cs
+++ b/src/ContentRepository/Packaging/Steps/Internal/CopyCustomAssemblies.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace SenseNet.Packaging.Steps.Internal
+{
+    public class CopyCustomAssemblies : Copy
+    {
+        public CopyCustomAssemblies()
+        {
+            Source = "Customization\\bin";
+            SourceIsRelativeTo = PathRelativeTo.Package;
+
+            // This will make the system copy everything from the bin folder above
+            // to the web\bin folder of the target application.
+            TargetDirectory = ".";
+        }
+
+        public override void Execute(ExecutionContext context)
+        {
+            var source = ResolvePackagePath(Source, context);
+            if (!Directory.Exists(source) || !Directory.EnumerateFileSystemEntries(source).Any())
+            {
+                Logger.LogMessage("No custom assemblies to copy.");
+                return;
+            }
+
+            base.Execute(context);
+        }
+    }
+}

--- a/src/ContentRepository/Packaging/Steps/Internal/ImportCustomContent.cs
+++ b/src/ContentRepository/Packaging/Steps/Internal/ImportCustomContent.cs
@@ -1,0 +1,28 @@
+﻿using SenseNet.ContentRepository;
+using System.IO;
+using System.Linq;
+
+namespace SenseNet.Packaging.Steps.Internal
+{
+    public class ImportCustomContent : Import
+    {
+        public ImportCustomContent()
+        {
+            Source = "Customization\\import";
+            SourceIsRelativeTo = PathRelativeTo.Package;
+            Target = Repository.RootPath;
+        }
+
+        public override void Execute(ExecutionContext context)
+        {
+            var source = ResolvePackagePath(Source, context);
+            if (!Directory.Exists(source) || !Directory.EnumerateFileSystemEntries(source).Any())
+            {
+                Logger.LogMessage("No custom content to import.");
+                return;
+            }
+
+            base.Execute(context);
+        }
+    }
+}


### PR DESCRIPTION
**The problem**: when there is a _breaking change in the API used by 3rd party libraries_ that we cannot control, the phase that tries to start the repository with the new libraries will fail because the custom library that is still there was built against the _old API_.

We have to provide a way for developers to **extend the patch** with the updated version of those libraries so that we can copy them over the same way as we copy our new libraries.

### Solution
Two new steps that can be placed into the manifest to the _appropriate position_: the same place where we copy our own new libraries or import new content items. 

- CopyCustomAssemblies
- ImportCustomContent

These steps expect custom libraries and content to be in the following **subfolder inside the patch**: 

- Customization\bin
- Customization\import

This way developers will be able to **compile and put their new libraries and updated content items into the patch** so that it can be executed on their environment.