### PR TITLE
Feature/serialize search

### DIFF
--- a/src/Search/Querying/Parser/Predicates/LogicalClause.cs
+++ b/src/Search/Querying/Parser/Predicates/LogicalClause.cs
@@ -1,4 +1,6 @@
-﻿namespace SenseNet.Search.Querying.Parser.Predicates
+﻿using System.Runtime.Serialization;
+
+namespace SenseNet.Search.Querying.Parser.Predicates
 {
     /// <summary>
     /// Defines clause occurence options in CQL queries.
@@ -27,15 +29,18 @@
     /// Defines a logical clause inspired by Lucene query syntax.
     /// This clause is any clause expanded by an occurence.
     /// </summary>
+    [DataContract]
     public class LogicalClause
     {
         /// <summary>
         /// Gets the base predicate of the clause.
         /// </summary>
-        public SnQueryPredicate Predicate { get; }
+        [DataMember]
+        public SnQueryPredicate Predicate { get; private set; }
         /// <summary>
         /// Gets or sets the occurence of the predicate.
         /// </summary>
+        [DataMember]
         public Occurence Occur { get; set; }
 
         /// <summary>

--- a/src/Search/Querying/Parser/Predicates/LogicalPredicate.cs
+++ b/src/Search/Querying/Parser/Predicates/LogicalPredicate.cs
@@ -1,16 +1,19 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace SenseNet.Search.Querying.Parser.Predicates
 {
     /// <summary>
     /// Defines a logical predicate that represents one level of the parenthesis in the CQL queries.
     /// </summary>
+    [DataContract]
     public class LogicalPredicate : SnQueryPredicate
     {
         /// <summary>
         /// Gets the list of the logical clauses.
         /// </summary>
-        public List<LogicalClause> Clauses { get; } = new List<LogicalClause>();
+        [DataMember]
+        public List<LogicalClause> Clauses { get; private set; } = new List<LogicalClause>();
 
         /// <summary>
         /// Initializes a new instance of LogicalPredicate with empty clause list.

--- a/src/Search/Querying/Parser/Predicates/RangePredicate.cs
+++ b/src/Search/Querying/Parser/Predicates/RangePredicate.cs
@@ -1,34 +1,42 @@
-﻿namespace SenseNet.Search.Querying.Parser.Predicates
+﻿using System.Runtime.Serialization;
+
+namespace SenseNet.Search.Querying.Parser.Predicates
 {
     /// <summary>
     /// Defines a range predicate inspired by Lucene query syntax.
     /// </summary>
+    [DataContract]
     public class RangePredicate : SnQueryPredicate
     {
         /// <summary>
         /// Gets the field name of the predicate.
         /// </summary>
-        public string FieldName { get; }
+        [DataMember]
+        public string FieldName { get; private set; }
 
         /// <summary>
         /// Gets the minimum value of the range. It can be null.
         /// </summary>
-        public IndexValue Min { get; }
+        [DataMember]
+        public IndexValue Min { get; private set; }
 
         /// <summary>
         /// Gets the maximum value of the range. It can be null.
         /// </summary>
-        public IndexValue Max { get; }
+        [DataMember]
+        public IndexValue Max { get; private set; }
 
         /// <summary>
         /// Gets the value that is true if the minimum value is in the range.
         /// </summary>
-        public bool MinExclusive { get; }
+        [DataMember]
+        public bool MinExclusive { get; private set; }
 
         /// <summary>
         /// Gets the value that is true if the maximum value is in the range.
         /// </summary>
-        public bool MaxExclusive { get; }
+        [DataMember]
+        public bool MaxExclusive { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of RangePredicate.

--- a/src/Search/Querying/Parser/Predicates/SimplePredicate.cs
+++ b/src/Search/Querying/Parser/Predicates/SimplePredicate.cs
@@ -1,24 +1,30 @@
-﻿namespace SenseNet.Search.Querying.Parser.Predicates
+﻿using System.Runtime.Serialization;
+
+namespace SenseNet.Search.Querying.Parser.Predicates
 {
     /// <summary>
     /// Represents a simple clause on the CQL query.
     /// </summary>
+    [DataContract]
     public class SimplePredicate : SnQueryPredicate
     {
         /// <summary>
         /// Gets the field name of the clause.
         /// </summary>
-        public string FieldName { get; }
+        [DataMember]
+        public string FieldName { get; private set; }
 
         /// <summary>
         /// Gets the value of the clause.
         /// </summary>
-        public IndexValue Value { get; }
+        [DataMember]
+        public IndexValue Value { get; private set; }
 
         /// <summary>
         /// Gets a value for compiling fuzzy queries.
         /// </summary>
-        public double? FuzzyValue { get; }
+        [DataMember]
+        public double? FuzzyValue { get; private set; }
 
         /// <summary>
         /// Initializes a new SimplePredicate instance.

--- a/src/Search/Querying/Parser/Predicates/SnQueryPredicate.cs
+++ b/src/Search/Querying/Parser/Predicates/SnQueryPredicate.cs
@@ -1,8 +1,15 @@
-﻿namespace SenseNet.Search.Querying.Parser.Predicates
+﻿using System.Runtime.Serialization;
+
+namespace SenseNet.Search.Querying.Parser.Predicates
 {
     /// <summary>
     /// The base class of the predicate class family used in SnQuery
     /// </summary>
+    [DataContract]
+    [KnownType(typeof(LogicalPredicate))]
+    [KnownType(typeof(RangePredicate))]
+    [KnownType(typeof(SimplePredicate))]
+    [KnownType(typeof(SnQueryPredicate))]
     public abstract class SnQueryPredicate
     {
         /// <summary>

--- a/src/Search/Querying/QueryResult.cs
+++ b/src/Search/Querying/QueryResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace SenseNet.Search.Querying
 {
@@ -6,6 +7,9 @@ namespace SenseNet.Search.Querying
     /// Represens a result of the SnQuery execution.
     /// </summary>
     /// <typeparam name="T">Can be int or string.</typeparam>
+    [DataContract]
+    [KnownType(typeof(QueryResult<int>))]
+    [KnownType(typeof(QueryResult<string>))]
     public class QueryResult<T>
     {
         /// <summary>
@@ -16,12 +20,14 @@ namespace SenseNet.Search.Querying
         /// <summary>
         /// Gets the resulted items.
         /// </summary>
-        public IEnumerable<T> Hits { get; }
+        [DataMember]
+        public IEnumerable<T> Hits { get; private set; }
 
         /// <summary>
         /// Gets the total count of permitted items without top and skip restrictions.
         /// </summary>
-        public int TotalCount { get; }
+        [DataMember]
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// Initializes a new QueryResult instance.

--- a/src/Search/Querying/SnQuery.cs
+++ b/src/Search/Querying/SnQuery.cs
@@ -1,10 +1,12 @@
-﻿using SenseNet.Search.Querying.Parser.Predicates;
+﻿using System.Runtime.Serialization;
+using SenseNet.Search.Querying.Parser.Predicates;
 
 namespace SenseNet.Search.Querying
 {
     /// <summary>
     /// Represents a parsed CQL query encapsulating all extensions.
     /// </summary>
+    [DataContract]
     public partial class SnQuery
     {
         /// <summary>
@@ -40,10 +42,12 @@ namespace SenseNet.Search.Querying
         /// <summary>
         /// Gets the original text representation of the query.
         /// </summary>
+        [DataMember]
         public string Querytext { get; internal set; }
         /// <summary>
         /// Gets the projection value. Default projection is NodeId.
         /// </summary>
+        [DataMember]
         public string Projection { get; internal set; }
         /// <summary>
         /// Gets or sets the maximum count of the query result.
@@ -65,6 +69,7 @@ namespace SenseNet.Search.Querying
         /// <summary>
         /// Gets the predicate tree representation of the query.
         /// </summary>
+        [DataMember]
         public SnQueryPredicate QueryTree { get; internal set; }
 
         /// <summary>

--- a/src/Search/Search.csproj
+++ b/src/Search/Search.csproj
@@ -47,6 +47,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Search/SortInfo.cs
+++ b/src/Search/SortInfo.cs
@@ -1,23 +1,27 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace SenseNet.Search
 {
     /// <summary>
     /// Represents a sorting criteria for querying.
     /// </summary>
+    [DataContract]
     [DebuggerDisplay("{" + nameof(ToString) + "()}")]
     public class SortInfo
     {
         /// <summary>
         /// Gets the field name.
         /// </summary>
-        public string FieldName { get; }
+        [DataMember]
+        public string FieldName { get; private set; }
 
         /// <summary>
         /// Gets the sorting direction. "False" means ascending, "true" means descending.
         /// </summary>
-        public bool Reverse { get; }
+        [DataMember]
+        public bool Reverse { get; private set; }
 
         /// <summary>
         /// Initializes an instance of the SortInfo


### PR DESCRIPTION
Make search-related classes serializable by adding the _[DataContract]_ and _[DataMember]_ attributes. No API changes were necessary, **only private setters were added**.