### PR TITLE
Make the OnMessageReceived virtual method proteced

### DIFF
--- a/src/Storage/DistributedApplication/Messaging/ClusterChannel.cs
+++ b/src/Storage/DistributedApplication/Messaging/ClusterChannel.cs
@@ -203,7 +203,7 @@ namespace SenseNet.Communication.Messaging
             if (MessageReceived != null)
                 MessageReceived(this, new MessageReceivedEventArgs(message));
         }
-        internal virtual void OnMessageReceived(Stream messageBody)
+        protected internal virtual void OnMessageReceived(Stream messageBody)
         {
             ClusterMessage message = m_formatter.Deserialize(messageBody);
             SnTrace.Messaging.Write("Received a '{0}' message.", message.GetType().FullName);


### PR DESCRIPTION
The _OnMessageReceived_ method is virtual so it can be overridden - but currently only inside the assembly. By adding the ```protected``` modifier we let 3rd party devs to create a custom cluster channel implementation that reuses the logic in the built-in base class.