### PR TITLE
Set permissions on generated Prrofiles container

### DIFF
--- a/src/ContentRepository/User.cs
+++ b/src/ContentRepository/User.cs
@@ -672,8 +672,18 @@ namespace SenseNet.ContentRepository
                 if (profiles == null)
                 {
                     var profilesTarget = Node.LoadNode(GetProfilesTargetPath());
-                    profiles = Content.CreateNew(Profiles, profilesTarget, Profiles).ContentHandler;
-                    profiles.Save();
+                    var pc = Content.CreateNew(Profiles, profilesTarget, Profiles);
+                    pc.Save();
+
+                    var aclEditor = SecurityHandler.CreateAclEditor();
+                    aclEditor.BreakInheritance(pc.Id)
+                        // ReSharper disable once CoVariantArrayConversion
+                        .Allow(pc.Id, Identifiers.AdministratorsGroupId, false, PermissionType.PermissionTypes)
+                        // ReSharper disable once CoVariantArrayConversion
+                        .Allow(pc.Id, Identifiers.OwnersGroupId, false, PermissionType.PermissionTypes)
+                        .Apply();
+
+                    profiles = pc.ContentHandler;
                 }
 
                 Content profile = null;


### PR DESCRIPTION
Break permissions and add full control for admins and owners on the Profiles container if it is generated by code.