### PR TITLE
Update the owner during node save only if it is the visitor.

### DIFF
--- a/src/Storage/Node.cs
+++ b/src/Storage/Node.cs
@@ -2579,7 +2579,12 @@ namespace SenseNet.ContentRepository.Storage
                                 this.Data.VersionModifiedById = adminId;
                                 this.Data.CreatedById = adminId;
                                 this.Data.ModifiedById = adminId;
-                                this.Data.OwnerId = adminId;
+
+                                // Re-set the owner only if it has not been changed (for example during
+                                // templated userprofile creation the new user should be the owner of the
+                                // content and this is set in the upper layer).
+                                if (this.Data.OwnerId == Identifiers.VisitorUserId)
+                                    this.Data.OwnerId = adminId;
                             }
                         }
                     }


### PR DESCRIPTION
If the owner has been changed in the upper layer (meaning it is not set to the Visitor), we should _not_ override it when saving a new node.