### PR TITLE
Fix/step populateindex

### DIFF
--- a/src/ContentRepository/Packaging/Steps/PopulateIndex.cs
+++ b/src/ContentRepository/Packaging/Steps/PopulateIndex.cs
@@ -29,7 +29,7 @@ namespace SenseNet.Packaging.Steps
         }
         // Method for indexing tests.
         internal void ExecuteInternal(ExecutionContext context,
-            EventHandler<NodeIndexedEventArgs> refreshed = null, //Action<object, NodeIndexedEventArgs> refreshed = null,
+            EventHandler<NodeIndexedEventArgs> refreshed = null,
             EventHandler<NodeIndexedEventArgs> indexed = null,
             EventHandler<NodeIndexingErrorEventArgs> error = null)
         {
@@ -113,6 +113,5 @@ namespace SenseNet.Packaging.Steps
         {
             Logger.LogException(e.Exception, $"Indexing error: NodeId: {e.NodeId}, VersionId: {e.VersionId}, Path: {e.Path}");
         }
-
     }
 }

--- a/src/ContentRepository/Packaging/Steps/PopulateIndex.cs
+++ b/src/ContentRepository/Packaging/Steps/PopulateIndex.cs
@@ -86,6 +86,7 @@ namespace SenseNet.Packaging.Steps
                 populator.NodeIndexed -= Populator_NodeIndexed;
                 RepositoryEnvironment.WorkingMode.Populating = savedMode;
 
+                context.Console.Write("                                                      \r");
                 context.Console.WriteLine();
             }
 

--- a/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
+++ b/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
@@ -74,8 +74,8 @@ namespace SenseNet.ContentRepository.Search.Indexing
                             {
                                 foreach (var node in n.LoadVersions())
                                 {
-                                    DataBackingStore.SaveIndexDocument(n, false, false, out _);
-                                    OnIndexDocumentRefreshed(n.Path, n.Id, n.VersionId, n.Version.ToString());
+                                    DataBackingStore.SaveIndexDocument(node, false, false, out _);
+                                    OnIndexDocumentRefreshed(node.Path, node.Id, node.VersionId, node.Version.ToString());
                                 }
                             });
                     }

--- a/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
+++ b/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
@@ -10,6 +10,7 @@ using SenseNet.ContentRepository.Storage.Search;
 using SenseNet.ContentRepository.Storage.Security;
 using SenseNet.Diagnostics;
 using SenseNet.Search;
+using SenseNet.Search.Indexing;
 using SenseNet.Search.Querying;
 
 namespace SenseNet.ContentRepository.Search.Indexing
@@ -39,15 +40,10 @@ namespace SenseNet.ContentRepository.Search.Indexing
                 IndexManager.ClearIndex();
                 consoleWriter?.WriteLine("ok");
 
-                IndexManager.AddDocuments(
-                    SearchManager.LoadIndexDocumentsByPath("/Root", IndexManager.GetNotIndexedNodeTypes())
-                        .Select(d =>
-                        {
-                            var indexDoc = IndexManager.CompleteIndexDocument(d);
-                            OnNodeIndexed(d.Path);
-                            return indexDoc;
-                        }));
+                IndexManager.AddDocuments(LoadIndexDocumentsByPath("/Root"));
 
+                // delete progress characters if there is
+                consoleWriter?.Write("                                             \n");
                 consoleWriter?.Write("  Commiting ... ");
                 IndexManager.Commit(); // explicit commit
                 consoleWriter?.WriteLine("ok");
@@ -82,13 +78,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
                 IndexManager.IndexingEngine.WriteIndex(
                     new[] {new SnTerm(IndexFieldName.InTree, path)},
                     null,
-                    SearchManager.LoadIndexDocumentsByPath(path, IndexManager.GetNotIndexedNodeTypes())
-                        .Select(d =>
-                        {
-                            var indexDoc = IndexManager.CompleteIndexDocument(d);
-                            OnNodeIndexed(d.Path);
-                            return indexDoc;
-                        }));
+                    LoadIndexDocumentsByPath(path));
                 op.Successful = true;
             }
         }
@@ -148,7 +138,8 @@ namespace SenseNet.ContentRepository.Search.Indexing
                     UpdateVersion(state, versioningInfo, indexDocument);
                 }
 
-                OnNodeIndexed(state.Node.Path);
+                var node = state.Node;
+                OnNodeIndexed(node.Path, node.Id, node.VersionId, node.Version.ToString());
 
                 op.Successful = true;
             }
@@ -266,13 +257,43 @@ namespace SenseNet.ContentRepository.Search.Indexing
 
 
         public event EventHandler<NodeIndexedEventArgs> NodeIndexed;
-        protected void OnNodeIndexed(string path)
+        protected void OnNodeIndexed(string path, int nodeId = 0, int versionId = 0, string version = null)
         {
-            NodeIndexed?.Invoke(null, new NodeIndexedEventArgs(path));
+            NodeIndexed?.Invoke(null, new NodeIndexedEventArgs(path, nodeId, versionId, version));
+        }
+        public event EventHandler<NodeIndexedEventArgs> IndexDocumentRefreshed;
+        protected void OnIndexDocumentRefreshed(string path, int nodeId = 0, int versionId = 0, string version = null)
+        {
+            IndexDocumentRefreshed?.Invoke(null, new NodeIndexedEventArgs(path, nodeId, versionId, version));
         }
 
+        public event EventHandler<NodeIndexingErrorEventArgs> IndexingError;
+        protected void OnIndexingError(IndexDocumentData doc, Exception exception)
+        {
+            IndexingError?.Invoke(null, new NodeIndexingErrorEventArgs(doc.NodeId, doc.VersionId, doc.Path, exception));
+        }
 
         /*================================================================================================================================*/
+
+        private IEnumerable<IndexDocument> LoadIndexDocumentsByPath(string path)
+        {
+            return SearchManager.LoadIndexDocumentsByPath(path, IndexManager.GetNotIndexedNodeTypes())
+                .Select(d =>
+                {
+                    try
+                    {
+                        var indexDoc = IndexManager.CompleteIndexDocument(d);
+                        OnNodeIndexed(d.Path, d.NodeId, d.VersionId, indexDoc.Version);
+                        return indexDoc;
+                    }
+                    catch (Exception e)
+                    {
+                        OnIndexingError(d, e);
+                        return null;
+                    }
+                })
+                .Where(d => d != null);
+        }
 
         // caller: CommitPopulateNode
         private static void CreateBrandNewNode(Node node, VersioningInfo versioningInfo, IndexDocumentData indexDocumentData)

--- a/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
+++ b/src/ContentRepository/Search/Indexing/DocumentPopulator.cs
@@ -42,7 +42,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
 
                 IndexManager.AddDocuments(LoadIndexDocumentsByPath("/Root"));
 
-                // delete progress characters if there is
+                // delete progress characters
                 consoleWriter?.Write("                                             \n");
                 consoleWriter?.Write("  Commiting ... ");
                 IndexManager.Commit(); // explicit commit

--- a/src/ContentRepository/Search/Indexing/NullPopulator.cs
+++ b/src/ContentRepository/Search/Indexing/NullPopulator.cs
@@ -23,6 +23,8 @@ namespace SenseNet.ContentRepository.Search.Indexing
 #pragma warning disable 0067
         // suppressed because it is not used but the interface declares.
         public event EventHandler<NodeIndexedEventArgs> NodeIndexed;
+        public event EventHandler<NodeIndexedEventArgs> IndexDocumentRefreshed;
+        public event EventHandler<NodeIndexingErrorEventArgs> IndexingError;
 #pragma warning restore 0067
         public void DeleteForest(IEnumerable<int> idSet) { }
         public void DeleteForest(IEnumerable<string> pathSet) { }

--- a/src/Storage/Search/IIndexPopulator.cs
+++ b/src/Storage/Search/IIndexPopulator.cs
@@ -94,8 +94,19 @@ namespace SenseNet.ContentRepository.Search.Indexing
         void RebuildIndex(Node node, bool recursive = false, IndexRebuildLevel rebuildLevel = IndexRebuildLevel.IndexOnly);
 
         /// <summary>
+        /// Defines an event that occurs when an index document refreshed.
+        /// </summary>
+        event EventHandler<NodeIndexedEventArgs> IndexDocumentRefreshed;
+
+        /// <summary>
         /// Defines an event that occurs when a node has just been indexed.
         /// </summary>
         event EventHandler<NodeIndexedEventArgs> NodeIndexed;
+
+        /// <summary>
+        /// Defines an event that occurs when a node indexing causes an error.
+        /// </summary>
+        event EventHandler<NodeIndexingErrorEventArgs> IndexingError;
+
     }
 }

--- a/src/Storage/Search/IIndexPopulator.cs
+++ b/src/Storage/Search/IIndexPopulator.cs
@@ -94,7 +94,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         void RebuildIndex(Node node, bool recursive = false, IndexRebuildLevel rebuildLevel = IndexRebuildLevel.IndexOnly);
 
         /// <summary>
-        /// Defines an event that occurs when an index document refreshed.
+        /// Defines an event that occurs when an index document is refreshed.
         /// </summary>
         event EventHandler<NodeIndexedEventArgs> IndexDocumentRefreshed;
 

--- a/src/Storage/Search/NodeIndexedEventArgs.cs
+++ b/src/Storage/Search/NodeIndexedEventArgs.cs
@@ -13,8 +13,17 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// Gets the path of the currently indexed node.
         /// </summary>
         public string Path { get; }
+        /// <summary>
+        /// Gets the id of the currently indexed node.
+        /// </summary>
         public int NodeId { get; }
+        /// <summary>
+        /// Gets the version id of the currently indexed node instance.
+        /// </summary>
         public int VersionId { get; }
+        /// <summary>
+        /// Gets the version of the currently indexed node instance.
+        /// </summary>
         public string Version { get; }
 
         /// <summary>

--- a/src/Storage/Search/NodeIndexedEventArgs.cs
+++ b/src/Storage/Search/NodeIndexedEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SenseNet.ContentRepository.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace SenseNet.ContentRepository.Search.Indexing
@@ -12,10 +13,19 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// Gets the path of the currently indexed node.
         /// </summary>
         public string Path { get; }
+        public int NodeId { get; }
+        public int VersionId { get; }
+        public string Version { get; }
 
         /// <summary>
         /// Initializes a new NodeIndexedEventArgs instance.
         /// </summary>
-        public NodeIndexedEventArgs(string path) { Path = path; }
+        public NodeIndexedEventArgs(string path, int nodeId = 0, int versionId = 0, string version = null)
+        {
+            Path = path;
+            NodeId = nodeId;
+            VersionId = versionId;
+            Version = version;
+        }
     }
 }

--- a/src/Storage/Search/NodeIndexingErrorEventArgs.cs
+++ b/src/Storage/Search/NodeIndexingErrorEventArgs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace SenseNet.ContentRepository.Search.Indexing
+{
+    /// <summary>
+    /// Defines an event argument containing the identifiers of the node that could not be indexed.
+    /// </summary>
+    public class NodeIndexingErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the id of the currently indexed node.
+        /// </summary>
+        public int NodeId { get; }
+        /// <summary>
+        /// Gets the id of the currently indexed version.
+        /// </summary>
+        public int VersionId { get; }
+        /// <summary>
+        /// Gets the path of the currently indexed node.
+        /// </summary>
+        public string Path { get; }
+        /// <summary>
+        /// Gets the indexing error.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Initializes a new NodeIndexedEventArgs instance.
+        /// </summary>
+        public NodeIndexingErrorEventArgs(int nodeId, int versionId, string path, Exception exception)
+        {
+            NodeId = nodeId;
+            VersionId = versionId;
+            Path = path;
+            Exception = exception;
+        }
+    }
+}

--- a/src/Storage/SenseNet.Storage.csproj
+++ b/src/Storage/SenseNet.Storage.csproj
@@ -257,6 +257,7 @@
     <Compile Include="NodeSaveSettings.cs" />
     <Compile Include="Package.cs" />
     <Compile Include="PreviewProvider.cs" />
+    <Compile Include="Search\NodeIndexingErrorEventArgs.cs" />
     <Compile Include="Search\QueryResult.cs" />
     <Compile Include="Retrier.cs" />
     <Compile Include="Search\SearchManager.cs" />

--- a/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
+++ b/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="StepTests\DeleteContentTypeTests.cs" />
     <Compile Include="StepTests\EditAllowedChildTypesTests.cs" />
     <Compile Include="StepTests\EditConfigurationTests.cs" />
+    <Compile Include="StepTests\PopulateIndexTests.cs" />
     <Compile Include="StepTests\UpgradeProviderConfigurationTests.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -106,6 +107,10 @@
     <ProjectReference Include="..\..\ContentRepository\SenseNet.ContentRepository.csproj">
       <Project>{786e6165-ca02-45a9-bf58-207a45d7d6df}</Project>
       <Name>SenseNet.ContentRepository</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Search\SenseNet.Search.csproj">
+      <Project>{0279705B-779D-485D-86B9-F7AB3DD1F2C3}</Project>
+      <Name>SenseNet.Search</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Storage\SenseNet.Storage.csproj">
       <Project>{5db4ddba-81f6-4d81-943a-18f3178b3355}</Project>

--- a/src/Tests/SenseNet.Packaging.Tests/StepTests/PopulateIndexTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/StepTests/PopulateIndexTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SenseNet.Configuration;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Search;
+using SenseNet.ContentRepository.Search.Indexing;
+using SenseNet.ContentRepository.Versioning;
+using SenseNet.ContentRepository.Workspaces;
+using SenseNet.Diagnostics;
+using SenseNet.Packaging.Steps;
+using SenseNet.Packaging.Tests.Implementations;
+using SenseNet.Tests;
+using SenseNet.Tests.Implementations;
+
+namespace SenseNet.Packaging.Tests.StepTests
+{
+    [TestClass]
+    public class PopulateIndexTests : TestBase
+    {
+        private static StringBuilder _log;
+        [TestInitialize]
+        public void PrepareTest()
+        {
+            // preparing logger
+            _log = new StringBuilder();
+            var loggers = new[] { new PackagingTestLogger(_log) };
+            var loggerAcc = new PrivateType(typeof(Logger));
+            loggerAcc.SetStaticField("_loggers", loggers);
+        }
+        [TestCleanup]
+        public void AfterTest()
+        {
+        }
+
+        [TestMethod]
+        public void Packaging_PopulateIndex_HardReindexWorksOnAllVersions()
+        {
+            Test(() =>
+            {
+                // arrange
+                InstallCarContentType();
+                var root = new SystemFolder(Repository.Root) {Name = "TestRoot"};
+                root.Save();
+
+                var workspace = new Workspace(root)
+                {
+                    Name = "Workspace-1",
+                    InheritableVersioningMode = InheritableVersioningType.MajorAndMinor
+                };
+                workspace.AllowChildType("Car");
+                workspace.Save();
+
+                var car1 = Content.CreateNew("Car", workspace, "Car1");
+                car1.Save();
+                var id = car1.Id;
+
+                // create some versions
+                car1 = Content.Load(id); car1.Publish();
+                car1 = Content.Load(id); car1.CheckOut();
+                car1 = Content.Load(id); car1.Index++; car1.Save();
+                car1.CheckIn();
+                car1 = Content.Load(id); car1.Index++; car1.Save();
+                car1 = Content.Load(id); car1.Index++; car1.Save();
+                car1 = Content.Load(id); car1.Publish();
+                car1 = Content.Load(id); car1.Index++; car1.Save();
+                car1 = Content.Load(id); car1.Index++; car1.Save();
+                car1 = Content.Load(id); car1.Publish();
+
+                var versions = car1.Versions.Select(n => n.Version.ToString()).ToArray();
+
+                var step = new PopulateIndex {Path = car1.Path, Level = "DatabaseAndIndex"};
+
+                var refreshedVersions = new List<string>();
+                var indexedVersions = new List<string>();
+                var refreshed = new EventHandler<NodeIndexedEventArgs>((sender, args) =>
+                {
+                    refreshedVersions.Add(args.Version.ToUpper());
+                });
+                var indexed = new EventHandler<NodeIndexedEventArgs>((sender, args) =>
+                {
+                    indexedVersions.Add(args.Version.ToUpper());
+                });
+
+                // action
+                step.ExecuteInternal(GetExecutionContext(), refreshed, indexed);
+
+                // assert
+                Assert.AreEqual(6, versions.Length);
+
+                refreshedVersions.Sort();
+                Assert.AreEqual(string.Join(",", versions), string.Join(",", refreshedVersions));
+
+                indexedVersions.Sort();
+                Assert.AreEqual(string.Join(",", versions), string.Join(",", indexedVersions));
+
+
+            });
+        }
+
+        private ExecutionContext GetExecutionContext()
+        {
+            var manifestXml = new XmlDocument();
+            manifestXml.LoadXml(@"<?xml version='1.0' encoding='utf-8'?>
+                    <Package type='Install'>
+                        <Id>MyCompany.MyComponent</Id>
+                        <ReleaseDate>2017-01-01</ReleaseDate>
+                        <Version>1.0</Version>
+                        <Steps>
+                            <Trace>Package is running.</Trace>
+                        </Steps>
+                    </Package>");
+
+            var phase = 0;
+            var console = new StringWriter();
+            var manifest = Manifest.Parse(manifestXml, phase, true, new PackageParameter[0]);
+            var executionContext = ExecutionContext.CreateForTest("packagePath", "targetPath", new string[0], "sandboxPath", manifest, phase, manifest.CountOfPhases, null, console);
+            executionContext.RepositoryStarted = true;
+            return executionContext;
+        }
+    }
+}


### PR DESCRIPTION
Modifications:
- IIndexPopulator and its implementation have 2 new events for tracing population progress and errors.
- The PopulateIndex step writes the progress and errors to the console.
- The DocumentPopulator become fault-tolerant: any error triggers an event and the processing is continued.
- The hard-reindex is fixed. All index documents are refreshed in the subtree and not just the top versions.
- These modifications are tested by an in-memory integration test.

Please check, merge and delete.
