### PR TITLE
Fix/clone stream

### DIFF
--- a/src/BlobStorage/Data/SqlClient/MsSqlBlobMetaDataProvider.cs
+++ b/src/BlobStorage/Data/SqlClient/MsSqlBlobMetaDataProvider.cs
@@ -410,16 +410,16 @@ SELECT @FileId
                     var providerName = reader.GetSafeString(3);
                     var providerTextData = reader.GetSafeString(4);
 
-                    byte[] rawData;
-                    if (reader.IsDBNull(5))
-                        rawData = null;
-                    else
-                        rawData = (byte[])reader.GetValue(5);
+                    byte[] rawData = null;
 
                     var provider = BlobStorageBase.GetProvider(providerName);
                     var context = new BlobStorageContext(provider, providerTextData) { VersionId = versionId, PropertyTypeId = propertyTypeId, FileId = fileId, Length = length };
                     if (provider == BlobStorageBase.BuiltInProvider)
+                    {
                         context.BlobProviderData = new BuiltinBlobProviderData();
+                        if (!reader.IsDBNull(5))
+                            rawData = (byte[])reader.GetValue(5);
+                    }
 
                     return new BinaryCacheEntity
                     {


### PR DESCRIPTION
Please check the changes.
- **UpdateBinaryProperty** methods: always create new rows in the Files table/collection.
- **LoadBinaryCacheEntity** method: no built-in stream used if the provider is external.

These changes are connected to other modifications of the following repositories:
- **sn-integrationtests**:  https://github.com/SenseNet/sn-integrationtests/tree/fix/clone-stream
- **sn-blob-mssqlfs**: https://github.com/SenseNet/sn-blob-mssqlfs/tree/fix/clone-stream
