### PR TITLE
No-Cache, No-Store, Must-Revalidate

### DIFF
--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -165,15 +165,16 @@ namespace SenseNet.Portal.Virtualization
         }
         public static void SetCacheControlHeaders(int cacheForSeconds, HttpCacheability httpCacheability)
         {
-            HttpContext.Current.Response.Cache.SetCacheability(httpCacheability);
+            var cache = HttpContext.Current.Response.Cache;
+            cache.SetCacheability(httpCacheability);
             if (httpCacheability == HttpCacheability.NoCache)
             {
-               HttpContext.Current.Response.Cache.SetNoStore();
-               HttpContext.Current.Response.Cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
-               HttpContext.Current.Response.Cache.SetValidUntilExpires(false);
+                cache.SetNoStore();
+                cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
+                cache.SetValidUntilExpires(false);
             }
-            HttpContext.Current.Response.Cache.SetMaxAge(new TimeSpan(0, 0, cacheForSeconds));
-            HttpContext.Current.Response.Cache.SetSlidingExpiration(true);  // max-age does not appear in response header without this...
+            cache.SetMaxAge(new TimeSpan(0, 0, cacheForSeconds));
+            cache.SetSlidingExpiration(true);  // max-age does not appear in response header without this...
         }
         public static void SetCacheControlHeaders(HttpCacheability? httpCacheability = null, DateTime? lastModified = null, TimeSpan? maxAge = null)
         {

--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -166,6 +166,12 @@ namespace SenseNet.Portal.Virtualization
         public static void SetCacheControlHeaders(int cacheForSeconds, HttpCacheability httpCacheability)
         {
             HttpContext.Current.Response.Cache.SetCacheability(httpCacheability);
+            if (httpCacheability == HttpCacheability.NoCache)
+            {
+               HttpContext.Current.Response.Cache.SetNoStore();
+               HttpContext.Current.Response.Cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
+               HttpContext.Current.Response.Cache.SetValidUntilExpires(false);
+            }
             HttpContext.Current.Response.Cache.SetMaxAge(new TimeSpan(0, 0, cacheForSeconds));
             HttpContext.Current.Response.Cache.SetSlidingExpiration(true);  // max-age does not appear in response header without this...
         }


### PR DESCRIPTION
Suggested during a security audit: in addition to "no-cache", we should set "no-store" and "must-revalidate" as well.