### PR TITLE
DeleteContentType step can handle more than one content type.

### DIFF
--- a/docs/snadmin-builtin-steps.md
+++ b/docs/snadmin-builtin-steps.md
@@ -893,11 +893,13 @@ If you want to modify the **content handler** of the content type, use this step
 - Default property: *Name*
 - Additional properties: *Delete*
 
-Deletes a content type and its usages. The execution mode depends on the value of the *Delete* property. Allowed values are:
+Deletes one or more content types and their usages. The execution mode depends on the value of the *Delete* property. Allowed values are:
 
 - No (default)
 - IfNotUsed
 - Force
+
+> If you want to delete multiple types, provide their names as a comma separated list in any order.
 
 #### No
 This is the default execution mode so the following two steps are equal:
@@ -930,7 +932,7 @@ The content type will be deleted even if there are dependencies in the repositor
 - Content templates
 - Content views
 - Allowed child types in all content type headers.
-- Allowed types in all CTD contfigurations of reference fields.
+- Allowed types in all CTD configurations of reference fields.
 - Allowed child types in all content instances.
 
 >Please make sure that a **StartRepository** step precedes this one to make sure that the repository is started.

--- a/src/ContentRepository/Packaging/Steps/DeleteContentType.cs
+++ b/src/ContentRepository/Packaging/Steps/DeleteContentType.cs
@@ -59,10 +59,9 @@ namespace SenseNet.Packaging.Steps
                 var rootTypeNamesText = string.Join(", ", rootTypeNames);
                 var plural = rootTypeNames.Length > 1;
 
-                //var currentContentType = ContentType.GetByName(name);
                 if (!rootTypeNames.Any())
                 {
-                    Logger.LogMessage("There is no any content type to delete.");
+                    Logger.LogMessage("There is no content type to delete.");
                     return;
                 }
 
@@ -431,6 +430,5 @@ WHERE p.Name = 'AllowedChildTypes' AND (
                 }
             }
         }
-
     }
 }

--- a/src/Tests/SenseNet.Packaging.Tests/StepTests/DeleteContentTypeTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/StepTests/DeleteContentTypeTests.cs
@@ -160,7 +160,7 @@ namespace SenseNet.Packaging.Tests.StepTests
                 Assert.AreEqual(contentTypeCount + 3, GetContentTypeCount());
 
                 // test
-                var step = new DeleteContentType {Name = "Car", Delete = DeleteContentType.Mode.Force};
+                var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
                 step.Execute(GetExecutionContext());
 
                 // check
@@ -185,7 +185,7 @@ namespace SenseNet.Packaging.Tests.StepTests
                 ContentTypeInstaller.InstallContentType(
                     string.Format(contentTypeTemplate, "Car1"),
                     string.Format(contentTypeTemplate, "Car2"));
-                var root = new SystemFolder(Repository.Root) {Name = "TestRoot"};
+                var root = new SystemFolder(Repository.Root) { Name = "TestRoot" };
                 root.Save();
                 var car0 = Content.CreateNew("Car", root, "Car0");
                 car0.Save();
@@ -196,7 +196,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(3, dependencies.InstanceCount);
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -240,7 +240,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount);
                 Assert.AreEqual(2, dependencies.PermittingContentTypes.Length);
@@ -258,7 +258,7 @@ namespace SenseNet.Packaging.Tests.StepTests
                 Assert.IsNull(ContentType.GetByName("Car2"));
                 Assert.AreEqual(contentTypeCount + 2, GetContentTypeCount());
 
-                var names = new[] {"Car", "Car1", "Car2"};
+                var names = new[] { "Car", "Car1", "Car2" };
 
                 var garage1 = ContentType.GetByName("Garage1");
                 Assert.IsFalse(garage1.AllowedChildTypeNames.Intersect(names).Any());
@@ -289,7 +289,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount);
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -367,7 +367,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount);
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -430,7 +430,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount); // Any instance in a content template is irrelevant.
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -478,7 +478,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount); // Any instance in a content template is irrelevant.
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -553,7 +553,7 @@ namespace SenseNet.Packaging.Tests.StepTests
 
                 // test-1
                 var step = new DeleteContentType { Name = "Car", Delete = DeleteContentType.Mode.Force };
-                var dependencies = step.GetDependencies(ContentType.GetByName("Car"));
+                var dependencies = step.GetDependencies(new[] { "Car" });
 
                 Assert.AreEqual(0, dependencies.InstanceCount); // Any instance in a content template is irrelevant.
                 Assert.AreEqual(0, dependencies.PermittingContentTypes.Length);
@@ -579,7 +579,8 @@ namespace SenseNet.Packaging.Tests.StepTests
         {
             Test(() =>
             {
-                var dependencies = new DeleteContentType.ContentTypeDependencies { ContentTypeName = "MyContentType" };
+                var dependencies =
+                    new DeleteContentType.ContentTypeDependencies { ContentTypeNames = new[] { "MyContentType" } };
                 Assert.IsFalse(dependencies.HasDependency);
 
                 // allowed types


### PR DESCRIPTION
The DeleteContentType step can handle more than one content type. These modifications are backported into the old sensenet version.