### PR TITLE
Pass child expands and selects to the projector when expanding the Children field

### DIFF
--- a/src/Services/OData/ExpanderProjector.cs
+++ b/src/Services/OData/ExpanderProjector.cs
@@ -165,8 +165,7 @@ namespace SenseNet.Portal.OData
                                             : FilterStatus.Disabled;
 
                                     return ProjectMultiRefContents(
-                                        c.Children.AsEnumerable().Select(cnt => cnt.ContentHandler),
-                                        new List<Property>(new[] { expansion }),
+                                        c.Children.AsEnumerable().Select(cnt => cnt.ContentHandler), expansion.Children,
                                         property.Children);
                                 });
                             break;

--- a/src/Services/OData/SimpleExpanderProjector.cs
+++ b/src/Services/OData/SimpleExpanderProjector.cs
@@ -107,9 +107,7 @@ namespace SenseNet.Portal.OData
 
                 var expansion = GetExpansion(ODataHandler.ChildrenPropertyName, expandTree);
 
-                return ProjectMultiRefContents(
-                    c.Children.AsEnumerable().Select(cnt => cnt.ContentHandler),
-                    new List<Property>(new[] { expansion }));
+                return ProjectMultiRefContents(c.Children.AsEnumerable().Select(cnt => cnt.ContentHandler), expansion.Children);
             });
 
             if (!outfields.ContainsKey(ICONPROPERTY))


### PR DESCRIPTION
The issue was that when you **expanded the Children field** (without $select), you got the whole subtree expanded instead of just one level.