### PR TITLE
Netstandard/remove entity

### DIFF
--- a/src/Services/SenseNet.Services.nuspec
+++ b/src/Services/SenseNet.Services.nuspec
@@ -25,7 +25,7 @@
       <dependency id="SenseNet.BlobStorage" version="7.3.2" />
       <dependency id="SenseNet.Common" version="7.2.0" />
       <dependency id="SenseNet.Security" version="3.0.0" />
-      <dependency id="SenseNet.Security.EF6SecurityStore" version="3.0.0" />
+      <dependency id="SenseNet.Security.EF6SecurityStore" version="3.0.1" />
       <dependency id="SenseNet.TaskManagement.Core" version="1.1.0.0" />
       <dependency id="SenseNet.TokenAuthentication" version="7.4.0.0" />
     </dependencies>

--- a/src/Storage/Configuration/Providers.cs
+++ b/src/Storage/Configuration/Providers.cs
@@ -11,7 +11,6 @@ using SenseNet.ContentRepository.Storage.Security;
 using SenseNet.Diagnostics;
 using SenseNet.Search;
 using SenseNet.Security;
-using SenseNet.Security.EF6SecurityStore;
 using SenseNet.Security.Messaging;
 using SenseNet.Tools;
 using System.Linq;

--- a/src/Storage/Configuration/Providers.cs
+++ b/src/Storage/Configuration/Providers.cs
@@ -40,7 +40,7 @@ namespace SenseNet.Configuration
         public static string SkinManagerClassName { get; internal set; } = GetProvider("SkinManager", "SenseNet.Portal.SkinManager");
         public static string DirectoryProviderClassName { get; internal set; } = GetProvider("DirectoryProvider");
         public static string SecurityDataProviderClassName { get; internal set; } = GetProvider("SecurityDataProvider",
-            typeof(EF6SecurityDataProvider).FullName);
+            "SenseNet.Security.EF6SecurityStore.EF6SecurityDataProvider");
         public static string SecurityMessageProviderClassName { get; internal set; } = GetProvider("SecurityMessageProvider", 
             typeof(DefaultMessageProvider).FullName);
         public static string DocumentPreviewProviderClassName { get; internal set; } = GetProvider("DocumentPreviewProvider",
@@ -164,9 +164,7 @@ namespace SenseNet.Configuration
 
             try
             {
-                // if other than the known implementation, create it automatically
-                if (string.Compare(SecurityDataProviderClassName, typeof(EF6SecurityDataProvider).FullName, StringComparison.Ordinal) != 0)
-                    securityDataProvider = (ISecurityDataProvider)TypeResolver.CreateInstance(SecurityDataProviderClassName);
+                securityDataProvider = (ISecurityDataProvider)TypeResolver.CreateInstance(SecurityDataProviderClassName);
             }
             catch (TypeNotFoundException)
             {
@@ -175,14 +173,6 @@ namespace SenseNet.Configuration
             catch (InvalidCastException)
             {
                 throw new ConfigurationException($"Invalid security data provider implementation: {SecurityDataProviderClassName}");
-            }
-
-            if (securityDataProvider == null)
-            {
-                // default implementation
-                securityDataProvider = new EF6SecurityDataProvider(
-                    Security.SecurityDatabaseCommandTimeoutInSeconds,
-                    ConnectionStrings.SecurityDatabaseConnectionString);
             }
 
             SnLog.WriteInformation("SecurityDataProvider created: " + securityDataProvider.GetType().FullName);

--- a/src/Storage/SenseNet.Storage.csproj
+++ b/src/Storage/SenseNet.Storage.csproj
@@ -64,23 +64,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.JScript" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SenseNet.Security, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SenseNet.Security.3.0.0\lib\netstandard2.0\SenseNet.Security.dll</HintPath>
-    </Reference>
-    <Reference Include="SenseNet.Security.EF6SecurityStore, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SenseNet.Security.EF6SecurityStore.3.0.0\lib\net461\SenseNet.Security.EF6SecurityStore.dll</HintPath>
     </Reference>
     <Reference Include="SenseNet.TaskManagement.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SenseNet.TaskManagement.Core.1.1.0.0\lib\net45\SenseNet.TaskManagement.Core.dll</HintPath>

--- a/src/Storage/StorageContext.cs
+++ b/src/Storage/StorageContext.cs
@@ -31,19 +31,6 @@ namespace SenseNet.ContentRepository.Storage
 
     public class StorageContext
     {
-        //TODO: well configuration resolves this problem.
-        internal void FixEfProviderServicesProblem()
-        {
-            // http://stackoverflow.com/questions/14033193/entity-framework-provider-type-could-not-be-loaded
-            // The Entity Framework provider type 'System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer'
-            // for the 'System.Data.SqlClient' ADO.NET provider could not be loaded. 
-            // Make sure the provider assembly is available to the running application. 
-            // See http://go.microsoft.com/fwlink/?LinkId=260882 for more information.
-
-            var instance = System.Data.Entity.SqlServer.SqlProviderServices.Instance;
-        }
-
-
         private static IL2Cache _l2Cache = new NullL2Cache();
         public static IL2Cache L2Cache
         {

--- a/src/Storage/packages.config
+++ b/src/Storage/packages.config
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="SenseNet.Security" version="3.0.0" targetFramework="net461" />
-  <package id="SenseNet.Security.EF6SecurityStore" version="3.0.0" targetFramework="net461" />
   <package id="SenseNet.TaskManagement.Core" version="1.1.0.0" targetFramework="net451" />
   <package id="SenseNet.Tools" version="3.1.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="4.5.0" targetFramework="net461" />


### PR DESCRIPTION
Remove EntityFramework hard dependency from sensenet. A soft dependency will remain, because the default security storage implementation is still in EF6, but the hardcoded project reference to EF can be removed.