### PR TITLE
Fix/avatar

### DIFF
--- a/src/ContentRepository/Fields/ImageField.cs
+++ b/src/ContentRepository/Fields/ImageField.cs
@@ -55,16 +55,38 @@ namespace SenseNet.ContentRepository.Fields
         }
         protected override object[] ConvertFrom(object value)
         {
-            _data = value as ImageFieldData;
+            ImageFieldData data = null;
+            if (value is int intValue)
+            {
+                if (Node.LoadNode(intValue) is Image refImage)
+                    data = new ImageFieldData(this, refImage, null);
+            }
+            else if (value is long longValue)
+            {
+                try
+                {
+                    var id = Convert.ToInt32(longValue);
+                    if (Node.LoadNode(id) is Image refImage)
+                        data = new ImageFieldData(this, refImage, null);
+                }
+                catch (Exception e)
+                {
+                    // ignored
+                }
+            }
+            else
+            {
+                data = value as ImageFieldData;
+            }
 
-            var data = value as ImageFieldData;
             if (data == null)
-                throw new NotSupportedException("Field value is null or not a ImageFieldData. FieldName: " + this.Name);
+                throw new NotSupportedException("Field value is null or not a valid ImageFieldData or an Int32. FieldName: " + this.Name);
+            _data = data;
 
-            object[] result = new object[2];
+            var result = new object[2];
 
             result[0] = data.ImgRef == null ? new List<Node>() : new List<Node>() { data.ImgRef };
-            result[1] = data.ImgData == null ? new BinaryData() : data.ImgData;
+            result[1] = data.ImgData ?? new BinaryData();
 
             return result;
         }

--- a/src/Services/OData/FieldConverter.cs
+++ b/src/Services/OData/FieldConverter.cs
@@ -65,7 +65,7 @@ namespace SenseNet.Portal.OData
                 throw new ODataException(SNSR.GetString(SNSR.Exceptions.OData.CannotConvertToJSON_2, typeof(ImageField.ImageFieldData).FullName, value.GetType().FullName), ODataExceptionCode.CannotConvertToJSON);
             writer.WriteStartObject();
             var url = imgData.Field == null ? "#" : ((ImageField)imgData.Field).ImageUrl;
-            writer.WritePropertyName("_deferred");
+            writer.WritePropertyName("Url");
             writer.WriteValue(url);
             writer.WriteEnd();
         }

--- a/src/Tests/SenseNet.Services.OData.Tests/ODataGeneralTests.cs
+++ b/src/Tests/SenseNet.Services.OData.Tests/ODataGeneralTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Fields;
 using SenseNet.Services.OData.Tests.Results;
 
 namespace SenseNet.Services.OData.Tests
@@ -648,5 +649,180 @@ namespace SenseNet.Services.OData.Tests
             });
         }
 
+        [TestMethod]
+        public void OData_UserAvatarByRef()
+        {
+            Test(() =>
+            {
+                var testDomain = new Domain(Repository.ImsFolder) { Name = "Domain1" };
+                testDomain.Save();
+
+                var testUser = new User(testDomain) { Name = "User1" };
+                testUser.Save();
+
+                var testSite = CreateTestSite();
+
+                var testAvatars = new Folder(testSite) { Name = "demoavatars" };
+                testAvatars.Save();
+
+                var testAvatar = new Image(testAvatars) { Name = "user1.jpg" };
+                testAvatar.Binary = new BinaryData { FileName = "user1.jpg" };
+                testAvatar.Binary.SetStream(RepositoryTools.GetStreamFromString("abcdefgh"));
+                testAvatar.Save();
+
+                // set avatar of User1
+                var userContent = Content.Load(testUser.Id);
+                var avatarContent = Content.Load(testAvatar.Id);
+                var avatarData = new ImageField.ImageFieldData(null, (Image)avatarContent.ContentHandler, null);
+                userContent["Avatar"] = avatarData;
+                userContent.Save();
+
+                // ACTION
+                var entity = ODataGET<ODataEntity>($"/OData.svc/Root/IMS/{testDomain.Name}('{testUser.Name}')",
+                    "metadata=no&$select=Avatar");
+
+                // ASSERT
+                var avatarString = entity.AllProperties["Avatar"].ToString();
+                Assert.IsTrue(avatarString.Contains("Url"));
+                Assert.IsTrue(avatarString.Contains(testAvatar.Path));
+            });
+        }
+        [TestMethod]
+        public void OData_UserAvatarUpdateRef()
+        {
+            Test(() =>
+            {
+                var testDomain = new Domain(Repository.ImsFolder) { Name = "Domain1" };
+                testDomain.Save();
+
+                var testUser = new User(testDomain) { Name = "User1" };
+                testUser.Save();
+
+                var testSite = CreateTestSite();
+
+                var testAvatars = new Folder(testSite) { Name = "demoavatars" };
+                testAvatars.Save();
+
+                var testAvatar1 = new Image(testAvatars) { Name = "user1.jpg" };
+                testAvatar1.Binary = new BinaryData { FileName = "user1.jpg" };
+                testAvatar1.Binary.SetStream(RepositoryTools.GetStreamFromString("abcdefgh"));
+                testAvatar1.Save();
+
+                var testAvatar2 = new Image(testAvatars) { Name = "user2.jpg" };
+                testAvatar2.Binary = new BinaryData { FileName = "user2.jpg" };
+                testAvatar2.Binary.SetStream(RepositoryTools.GetStreamFromString("ijklmnop"));
+                testAvatar2.Save();
+
+                // set avatar of User1
+                var userContent = Content.Load(testUser.Id);
+                var avatarContent = Content.Load(testAvatar1.Id);
+                var avatarData = new ImageField.ImageFieldData(null, (Image)avatarContent.ContentHandler, null);
+                userContent["Avatar"] = avatarData;
+                userContent.Save();
+
+                // ACTION
+                var result = ODataPATCH<ODataEntity>($"/OData.svc/Root/IMS/{testDomain.Name}('{testUser.Name}')",
+                    "metadata=no&$select=Avatar,ImageRef,ImageData",
+                    $"(models=[{{\"Avatar\": {testAvatar2.Id}}}])");
+
+                // ASSERT
+                if (result is ODataError error)
+                    Assert.AreEqual("", error.Message);
+                var entity = result as ODataEntity;
+                if (entity == null)
+                    Assert.Fail($"Result is {result.GetType().Name} but ODataEntity is expected.");
+
+                var avatarString = entity.AllProperties["Avatar"].ToString();
+                Assert.IsTrue(avatarString.Contains("Url"));
+                Assert.IsTrue(avatarString.Contains(testAvatar2.Path));
+            });
+        }
+        [TestMethod]
+        public void OData_UserAvatarByInnerData()
+        {
+            Test(() =>
+            {
+                var testDomain = new Domain(Repository.ImsFolder) { Name = "Domain1" };
+                testDomain.Save();
+
+                var testUser = new User(testDomain) { Name = "User1" };
+                testUser.Save();
+
+                var testSite = CreateTestSite();
+
+                var testAvatars = new Folder(testSite) { Name = "demoavatars" };
+                testAvatars.Save();
+
+                var testAvatar = new Image(testAvatars) { Name = "user1.jpg" };
+                testAvatar.Binary = new BinaryData { FileName = "user1.jpg" };
+                testAvatar.Binary.SetStream(RepositoryTools.GetStreamFromString("abcdefgh"));
+                testAvatar.Save();
+
+                var avatarBinaryData = new BinaryData { FileName = "user2.jpg" };
+                avatarBinaryData.SetStream(RepositoryTools.GetStreamFromString("ijklmnop"));
+
+                // set avatar of User1
+                var userContent = Content.Load(testUser.Id);
+                var avatarData = new ImageField.ImageFieldData(null, null, avatarBinaryData);
+                userContent["Avatar"] = avatarData;
+                userContent.Save();
+
+                // ACTION
+                var entity = ODataGET<ODataEntity>($"/OData.svc/Root/IMS/{testDomain.Name}('{testUser.Name}')",
+                    "metadata=no&$select=Avatar,ImageRef,ImageData");
+
+                // ASSERT
+                var avatarString = entity.AllProperties["Avatar"].ToString();
+                Assert.IsTrue(avatarString.Contains("Url"));
+                Assert.IsTrue(avatarString.Contains($"/binaryhandler.ashx?nodeid={testUser.Id}&propertyname=ImageData"));
+            });
+        }
+        [TestMethod]
+        public void OData_UserAvatarUpdateInnerDataToRef()
+        {
+            Test(() =>
+            {
+                var testDomain = new Domain(Repository.ImsFolder) { Name = "Domain1" };
+                testDomain.Save();
+
+                var testUser = new User(testDomain) { Name = "User1" };
+                testUser.Save();
+
+                var testSite = CreateTestSite();
+
+                var testAvatars = new Folder(testSite) { Name = "demoavatars" };
+                testAvatars.Save();
+
+                var testAvatar = new Image(testAvatars) { Name = "user1.jpg" };
+                testAvatar.Binary = new BinaryData { FileName = "user1.jpg" };
+                testAvatar.Binary.SetStream(RepositoryTools.GetStreamFromString("abcdefgh"));
+                testAvatar.Save();
+
+                var avatarBinaryData = new BinaryData { FileName = "user2.jpg" };
+                avatarBinaryData.SetStream(RepositoryTools.GetStreamFromString("ijklmnop"));
+
+                // set avatar of User1
+                var userContent = Content.Load(testUser.Id);
+                var avatarData = new ImageField.ImageFieldData(null, null, avatarBinaryData);
+                userContent["Avatar"] = avatarData;
+                userContent.Save();
+
+                // ACTION
+                var result = ODataPATCH<ODataEntity>($"/OData.svc/Root/IMS/{testDomain.Name}('{testUser.Name}')",
+                    "metadata=no&$select=Avatar,ImageRef,ImageData",
+                    $"(models=[{{\"Avatar\": {testAvatar.Id}}}])");
+
+                // ASSERT
+                if(result is ODataError error)
+                    Assert.AreEqual("", error.Message);
+                var entity = result as ODataEntity;
+                if (entity == null)
+                    Assert.Fail($"Result is {result.GetType().Name} but ODataEntity is expected.");
+
+                var avatarString = entity.AllProperties["Avatar"].ToString();
+                Assert.IsTrue(avatarString.Contains("Url"));
+                Assert.IsTrue(avatarString.Contains(testAvatar.Path));
+            });
+        }
     }
 }

--- a/src/Tests/SenseNet.Services.OData.Tests/ODataTestClass.cs
+++ b/src/Tests/SenseNet.Services.OData.Tests/ODataTestClass.cs
@@ -21,6 +21,7 @@ namespace SenseNet.Services.OData.Tests
 {
     public abstract class ODataTestClass : TestBase
     {
+        // ReSharper disable once InconsistentNaming
         internal static T ODataGET<T>(string resource, string queryString) where T : IODataResult
         {
             using (var output = new System.IO.StringWriter())
@@ -32,6 +33,26 @@ namespace SenseNet.Services.OData.Tests
                 return (T)GetResult<T>(output);
             }
         }
+
+        // ReSharper disable once InconsistentNaming
+        internal static IODataResult ODataPATCH<T>(string resource, string queryString, string requestData) where T : IODataResult
+        {
+            using (var requestStream = RepositoryTools.GetStreamFromString(requestData))
+                return ODataPATCH<T>(resource, queryString, requestStream);
+        }
+        // ReSharper disable once InconsistentNaming
+        internal static IODataResult ODataPATCH<T>(string resource, string queryString, Stream requestStream) where T : IODataResult
+        {
+            using (var output = new System.IO.StringWriter())
+            {
+                var pc = CreatePortalContext(resource, queryString, output);
+                var handler = new ODataHandler();
+                handler.ProcessRequest(pc.OwnerHttpContext, "PATCH", requestStream);
+                output.Flush();
+                return (T)GetResult<T>(output);
+            }
+        }
+
         internal static IODataResult GetResult<T>(System.IO.StringWriter output) where T : IODataResult
         {
             if (typeof(T) == typeof(ODataEntity))
@@ -54,7 +75,6 @@ namespace SenseNet.Services.OData.Tests
             }
             throw new NotImplementedException();
         }
-
 
         protected const string TestSiteName = "ODataTestSite";
         protected static string TestSitePath => RepositoryPath.Combine("/Root/Sites", TestSiteName);


### PR DESCRIPTION
Please approve/merge etc. Main changes:
- In an OData response, the Avatar property value is an object that has only one property: "Url" (it was "_deferred" with one underscore). The value can be a content path or a link to the downloadable stream.
- In an OData response, the Avatar property is NOT expandable, it's value can be used directly.
- The Avatar property is upgradeable through OData API with the Id of the target content. The target content needs to be an Image. For example:
  - Request: `PATCH /OData.svc/Root/IMS/Domain1('User1')?metadata=no&$select=Avatar,...`
  - Stream: `(models=["Avatar": 42])`
- A new method for easy OData tests: `ODataPATCH<T>(resource, queryString, requestData)`