### PR TITLE
Add a temporary solution to avoid duplicated dlls.

### DIFF
--- a/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.Security.Policy;
 using System.Text;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SenseNet.ContentRepository;
 using SenseNet.ContentRepository.Storage;
+using SenseNet.Diagnostics;
 using SenseNet.Packaging.Tests.Implementations;
 using SenseNet.Tests;
 
@@ -13,6 +16,13 @@ namespace SenseNet.Packaging.Tests
     [TestClass]
     public abstract class PackagingTestBase : TestBase
     {
+        [AssemblyInitialize]
+        public static void InitializeAssembly(TestContext context)
+        {
+            //TODO: Find a correct solution to avoid assembly duplications and remove this line
+            var dummy = typeof(SenseNet.Portal.OData.ODataHandler).Name;
+        }
+
         protected static StringBuilder _log;
         private IPackageStorageProviderFactory _packageStorageProviderFactoryBackup;
         [TestInitialize]

--- a/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
+++ b/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
@@ -113,6 +113,10 @@
       <Project>{0279705B-779D-485D-86B9-F7AB3DD1F2C3}</Project>
       <Name>SenseNet.Search</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Services\SenseNet.Services.csproj">
+      <Project>{b72529c8-feb1-49f5-b08b-56055b58f296}</Project>
+      <Name>SenseNet.Services</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Storage\SenseNet.Storage.csproj">
       <Project>{5db4ddba-81f6-4d81-943a-18f3178b3355}</Project>
       <Name>SenseNet.Storage</Name>


### PR DESCRIPTION
Please accept this temporary change. A long-term investigation did not help to explore the real problem. This temporary solution is small and affects only one test project.