### PR TITLE
GetEffectiveEntries works with all permission entry types.

### DIFF
--- a/src/ContentRepository/ContentTemplate.cs
+++ b/src/ContentRepository/ContentTemplate.cs
@@ -357,7 +357,7 @@ namespace SenseNet.ContentRepository
             // inherit explicit permissions from template
             using (new SystemAccount())
             {
-                var entries = SecurityHandler.GetExplicitEntriesAsSystemUser(sourceNode.Id);
+                var entries = SecurityHandler.GetExplicitEntriesAsSystemUser(sourceNode.Id, null, EntryType.Normal);
                 if (entries.Count > 0)
                 {
                     var aclEdit = SecurityHandler.CreateAclEditor();

--- a/src/ContentRepository/Security/PermissionQuery.cs
+++ b/src/ContentRepository/Security/PermissionQuery.cs
@@ -227,7 +227,7 @@ namespace SenseNet.ContentRepository.Security
             var parent = singleContent ? content.ContentHandler.Parent : content.ContentHandler;
             var effectiveParentEntries = parent == null || !parent.Security.HasPermission(PermissionType.SeePermissions) 
                 ? new AceInfo[0]
-                : parent.Security.GetEffectiveEntries().Where(e => identities.Contains(e.IdentityId) && !e.LocalOnly).ToArray();
+                : parent.Security.GetEffectiveEntries(EntryType.Normal).Where(e => identities.Contains(e.IdentityId) && !e.LocalOnly).ToArray();
 
             var permissionsTypes = PermissionType.BuiltInPermissionTypes.Select(p => new PermissionInfo { Index = p.Index, Name = p.Name }).ToArray();
 
@@ -279,7 +279,7 @@ namespace SenseNet.ContentRepository.Security
             // If the current user (who browses the permission overview page) has no SeePermission
             // permission for the content, simply use an empty array.
             var explicitPermissions = canSeePermissions
-                ? content.Security.GetExplicitEntries().Where(e => identities.Contains(e.IdentityId)).ToArray()
+                ? content.Security.GetExplicitEntries(EntryType.Normal).Where(e => identities.Contains(e.IdentityId)).ToArray()
                 : new AceInfo[0];
             var explicitLocalOnlyPermissions = explicitPermissions.Where(ace => ace.LocalOnly).ToArray();
 

--- a/src/ContentRepository/Sharing/SharingHandler.cs
+++ b/src/ContentRepository/Sharing/SharingHandler.cs
@@ -437,7 +437,7 @@ namespace SenseNet.ContentRepository.Sharing
         internal void UpdatePermissions()
         {
             var aclEditor = SnSecurityContext.Create().CreateAclEditor(EntryType.Sharing);
-            var currentEntries = GetExplicitEntries();
+            var currentEntries = GetExplicitSharingEntries();
 
             // first remove all existing entries
             foreach (var currentEntry in currentEntries)
@@ -520,32 +520,16 @@ namespace SenseNet.ContentRepository.Sharing
             return bits;
         }
 
-        internal List<AceInfo> GetExplicitEntries()
+        internal List<AceInfo> GetExplicitSharingEntries()
         {
-            return GetExplicitEntries(_owner.Id);
-        }
-        internal static List<AceInfo> GetExplicitEntries(int contentId, IEnumerable<int> relatedIdentities = null)
-        {
-            SecurityHandler.SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            return GetExplicitEntriesAsSystemUser(contentId, relatedIdentities);
-        }
-        internal static List<AceInfo> GetExplicitEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null)
-        {
-            return SecurityHandler.SecurityContext.GetExplicitEntries(contentId, relatedIdentities, EntryType.Sharing);
+            SecurityHandler.SecurityContext.AssertPermission(_owner.Id, PermissionType.SeePermissions);
+            return SecurityHandler.SecurityContext.GetExplicitEntries(_owner.Id, null, EntryType.Sharing);
         }
 
-        internal List<AceInfo> GetEffectiveEntries()
+        internal List<AceInfo> GetEffectiveSharingEntries()
         {
-            return GetEffectiveEntries(_owner.Id);
-        }
-        internal static List<AceInfo> GetEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null)
-        {
-            SecurityHandler.SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            return GetEffectiveEntriesAsSystemUser(contentId, relatedIdentities);
-        }
-        internal static List<AceInfo> GetEffectiveEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null)
-        {
-            return SecurityHandler.SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, EntryType.Sharing);
+            SecurityHandler.SecurityContext.AssertPermission(_owner.Id, PermissionType.SeePermissions);
+            return SecurityHandler.SecurityContext.GetEffectiveEntries(_owner.Id, null, EntryType.Sharing);
         }
 
         /* ================================================================================== Notifications */

--- a/src/ContentRepository/Tools.cs
+++ b/src/ContentRepository/Tools.cs
@@ -368,7 +368,7 @@ namespace SenseNet.ContentRepository
             {
                 var hasEveryoneEntry = false;
                 var hasVisitorEntry = false;
-                foreach (var entry in node.Security.GetExplicitEntries())
+                foreach (var entry in node.Security.GetExplicitEntries(EntryType.Normal))
                 {
                     if (entry.IdentityId == everyoneId)
                         hasEveryoneEntry = true;

--- a/src/ContentRepository/TrashBag.cs
+++ b/src/ContentRepository/TrashBag.cs
@@ -250,6 +250,8 @@ namespace SenseNet.ContentRepository
             // copy permissions from the source content, without reseting the permission system
             SecurityHandler.CopyPermissionsFrom(source.Id, target.Id, CopyPermissionMode.BreakAndClear);
 
+            //UNDONE: do we need to deal with Sharing permissions here, or just Normal?
+
             // If there were any permission settings for the Creators group on the source content, we 
             // need to place an explicite entry with the same permissions onto the target for the creator 
             // user, as the creator of the trashbag (the user who deletes the content) may be different 

--- a/src/ContentRepository/TrashBag.cs
+++ b/src/ContentRepository/TrashBag.cs
@@ -9,6 +9,7 @@ using SenseNet.ContentRepository.Storage.Data;
 using SenseNet.ContentRepository.Storage.Schema;
 using SenseNet.Diagnostics;
 using SenseNet.ContentRepository.Storage.Security;
+using SenseNet.Security;
 
 namespace SenseNet.ContentRepository
 {
@@ -254,9 +255,13 @@ namespace SenseNet.ContentRepository
             // need to place an explicite entry with the same permissions onto the target for the creator 
             // user, as the creator of the trashbag (the user who deletes the content) may be different 
             // than the creator of the original document.
-            var aces = SecurityHandler.GetEffectiveEntriesAsSystemUser(source.Id, new[] { Identifiers.OwnersGroupId });
+            var aces = SecurityHandler.GetEffectiveEntriesAsSystemUser(source.Id, new[] { Identifiers.OwnersGroupId }, EntryType.Normal);
             foreach (var ace in aces)
                 SecurityHandler.CreateAclEditor().Set(target.Id, ace.IdentityId, ace.LocalOnly, ace.AllowBits, ace.DenyBits);
+
+            aces = SecurityHandler.GetEffectiveEntriesAsSystemUser(source.Id, new[] { Identifiers.OwnersGroupId }, EntryType.Sharing);
+            foreach (var ace in aces)
+                SnAclEditor.Create(SecurityHandler.SecurityContext, EntryType.Sharing).Set(target.Id, ace.IdentityId, ace.LocalOnly, ace.AllowBits, ace.DenyBits);
         }
 
 

--- a/src/ContentRepository/TrashBag.cs
+++ b/src/ContentRepository/TrashBag.cs
@@ -250,8 +250,6 @@ namespace SenseNet.ContentRepository
             // copy permissions from the source content, without reseting the permission system
             SecurityHandler.CopyPermissionsFrom(source.Id, target.Id, CopyPermissionMode.BreakAndClear);
 
-            //UNDONE: do we need to deal with Sharing permissions here, or just Normal?
-
             // If there were any permission settings for the Creators group on the source content, we 
             // need to place an explicite entry with the same permissions onto the target for the creator 
             // user, as the creator of the trashbag (the user who deletes the content) may be different 

--- a/src/Services/Dws/DwsHandler.cs
+++ b/src/Services/Dws/DwsHandler.cs
@@ -17,6 +17,7 @@ using SenseNet.Search;
 using SenseNet.ContentRepository.Schema;
 using SenseNet.ContentRepository.Workspaces;
 using SenseNet.Configuration;
+using SenseNet.Security;
 
 namespace SenseNet.Portal.Dws
 {
@@ -697,7 +698,7 @@ namespace SenseNet.Portal.Dws
             {
                 try
                 {
-                    foreach (var member in this.RequestedNode.Security.GetEffectiveEntries().Select(entry => entry.IdentityId).Distinct()
+                    foreach (var member in this.RequestedNode.Security.GetEffectiveEntries(EntryType.Normal).Select(entry => entry.IdentityId).Distinct()
                             .Select(Node.LoadNode).Where(node => node != null))
                     {
                         var user = member as User;

--- a/src/Storage/Node.cs
+++ b/src/Storage/Node.cs
@@ -3389,7 +3389,7 @@ namespace SenseNet.ContentRepository.Storage
             AccessProvider.ChangeToSystemAccount();
             try
             {
-                var entriesToCopy = SecurityHandler.GetExplicitEntriesAsSystemUser(sourceNode.Id);
+                var entriesToCopy = SecurityHandler.GetExplicitEntriesAsSystemUser(sourceNode.Id, null, EntryType.Normal);
                 if (entriesToCopy.Count == 0)
                     return;
 

--- a/src/Storage/Search/PermissionFilter.cs
+++ b/src/Storage/Search/PermissionFilter.cs
@@ -152,7 +152,7 @@ namespace SenseNet.Search.Querying
             try
             {
                 using (new SystemAccount())
-                    entries = SecurityHandler.GetEffectiveEntries(nodeId);
+                    entries = SecurityHandler.GetAllEffectiveEntries(nodeId);
             }
             catch (Exception ex) // LOGGED
             {

--- a/src/Storage/Search/PermissionFilter.cs
+++ b/src/Storage/Search/PermissionFilter.cs
@@ -152,7 +152,7 @@ namespace SenseNet.Search.Querying
             try
             {
                 using (new SystemAccount())
-                    entries = SecurityHandler.GetAllEffectiveEntries(nodeId);
+                    entries = SecurityHandler.GetEffectiveEntries(nodeId);
             }
             catch (Exception ex) // LOGGED
             {

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -781,64 +781,63 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <summary>
         /// Return with the current content's explicit entries. Current user must have SeePermissions permission.
         /// </summary>
-        public List<AceInfo> GetExplicitEntries()
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public List<AceInfo> GetExplicitEntries(EntryType? entryType = null)
         {
-            return GetExplicitEntries(_node.Id);
+            return GetExplicitEntries(_node.Id, null, entryType);
         }
         /// <summary>
         /// Return with the passed content's explicit entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
-        public static List<AceInfo> GetExplicitEntries(int contentId, IEnumerable<int> relatedIdentities = null)
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public static List<AceInfo> GetExplicitEntries(int contentId, IEnumerable<int> relatedIdentities = null, EntryType? entryType = null)
         {
             SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            return GetExplicitEntriesAsSystemUser(contentId, relatedIdentities);
+            return GetExplicitEntriesAsSystemUser(contentId, relatedIdentities, entryType);
         }
-
-        /// <summary>
-        /// Return with the passed content's explicit entries. There is permission check so you must call this method from a safe block.
-        /// </summary>
-        /// <param name="contentId">Id of the content.</param>
-        /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
-	    public static List<AceInfo> GetExplicitEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null)
+	    /// <summary>
+	    /// Return with the passed content's explicit entries. There is permission check so you must call this method from a safe block.
+	    /// </summary>
+	    /// <param name="contentId">Id of the content.</param>
+	    /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
+	    /// <param name="entryType">Security entry type. Default: all entries.</param>
+	    public static List<AceInfo> GetExplicitEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null, EntryType? entryType = null)
 	    {
-	        return SecurityContext.GetExplicitEntries(contentId, relatedIdentities, EntryType.Normal);
+	        return SecurityContext.GetExplicitEntries(contentId, relatedIdentities, entryType);
 	    }
 
-	    /// <summary>
+        /// <summary>
         /// Return with the current content's effective entries. Current user must have SeePermissions permission.
         /// </summary>
-        public List<AceInfo> GetEffectiveEntries()
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public List<AceInfo> GetEffectiveEntries(EntryType? entryType = null)
         {
-            return GetEffectiveEntries(_node.Id);
+            return GetEffectiveEntries(_node.Id, null, entryType);
         }
         /// <summary>
         /// Return with the passed content's effective entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
-        public static List<AceInfo> GetEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null)
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public static List<AceInfo> GetEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null, EntryType? entryType = null)
         {
             SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            //return GetEffectiveEntriesAsSystemUser(contentId, relatedIdentities);
-            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities);
+            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, entryType);
         }
         /// <summary>
         /// Return with the passed content's effective entries. There is permission check so you must call this method from a safe block.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
-        public static List<AceInfo> GetEffectiveEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null)
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public static List<AceInfo> GetEffectiveEntriesAsSystemUser(int contentId, IEnumerable<int> relatedIdentities = null, EntryType? entryType = null)
         {
-            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, EntryType.Normal);
+            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, entryType);
         }
 
-	    public static List<AceInfo> GetAllEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null)
-	    {
-	        SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities);
-	    }
         #endregion
 
         #region /*========================================================== ACL */

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -758,7 +758,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             if (identities.First() == Identifiers.SystemUserId)
                 return PermittedLevel.All;
 
-            var aces = SecurityContext.GetEffectiveEntries(nodeId, identities);
+            var aces = GetEffectiveEntriesAsSystemUser(nodeId, identities);
 
             if (aces.Count == 0)
                 return PermittedLevel.None;

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -758,7 +758,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             if (identities.First() == Identifiers.SystemUserId)
                 return PermittedLevel.All;
 
-            var aces = GetEffectiveEntriesAsSystemUser(nodeId, identities);
+            var aces = SecurityContext.GetEffectiveEntries(nodeId, identities);
 
             if (aces.Count == 0)
                 return PermittedLevel.None;
@@ -821,7 +821,8 @@ namespace SenseNet.ContentRepository.Storage.Security
         public static List<AceInfo> GetEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null)
         {
             SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
-            return GetEffectiveEntriesAsSystemUser(contentId, relatedIdentities);
+            //return GetEffectiveEntriesAsSystemUser(contentId, relatedIdentities);
+            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities);
         }
         /// <summary>
         /// Return with the passed content's effective entries. There is permission check so you must call this method from a safe block.
@@ -832,6 +833,12 @@ namespace SenseNet.ContentRepository.Storage.Security
         {
             return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, EntryType.Normal);
         }
+
+	    public static List<AceInfo> GetAllEffectiveEntries(int contentId, IEnumerable<int> relatedIdentities = null)
+	    {
+	        SecurityContext.AssertPermission(contentId, PermissionType.SeePermissions);
+            return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities);
+	    }
         #endregion
 
         #region /*========================================================== ACL */

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -781,9 +781,10 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <summary>
         /// Returns the current content's explicit normal entries. Current user must have SeePermissions permission.
         /// </summary>
-        public List<AceInfo> GetExplicitEntries()
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public List<AceInfo> GetExplicitEntries(EntryType? entryType = null)
         {
-            return GetExplicitEntries(_node.Id, null, EntryType.Normal);
+            return GetExplicitEntries(_node.Id, null, entryType);
         }
         /// <summary>
         /// Return with the passed content's explicit entries. Current user must have SeePermissions permission.
@@ -810,9 +811,10 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <summary>
         /// Returns the current content's effective normal entries. Current user must have SeePermissions permission.
         /// </summary>
-        public List<AceInfo> GetEffectiveEntries()
+        /// <param name="entryType">Security entry type. Default: all entries.</param>
+        public List<AceInfo> GetEffectiveEntries(EntryType? entryType = null)
         {
-            return GetEffectiveEntries(_node.Id, null, EntryType.Normal);
+            return GetEffectiveEntries(_node.Id, null, entryType);
         }
         /// <summary>
         /// Return with the passed content's effective entries. Current user must have SeePermissions permission.
@@ -1822,7 +1824,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         {
             if (!_node.IsInherited)
                 writer.WriteElementString("Break", null);
-            var entries = _node.Security.GetExplicitEntries();
+            var entries = _node.Security.GetExplicitEntries(EntryType.Normal);
             foreach (var entry in entries)
                 entry.Export(writer);
         }

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -779,7 +779,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         }
 
         /// <summary>
-        /// Returns the current content's explicit normal entries. Current user must have SeePermissions permission.
+        /// Returns the current content's explicit entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="entryType">Security entry type. Default: all entries.</param>
         public List<AceInfo> GetExplicitEntries(EntryType? entryType = null)
@@ -787,7 +787,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             return GetExplicitEntries(_node.Id, null, entryType);
         }
         /// <summary>
-        /// Return with the passed content's explicit entries. Current user must have SeePermissions permission.
+        /// Return the passed content's explicit entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
@@ -798,7 +798,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             return GetExplicitEntriesAsSystemUser(contentId, relatedIdentities, entryType);
         }
 	    /// <summary>
-	    /// Return with the passed content's explicit entries. There is permission check so you must call this method from a safe block.
+	    /// Return the passed content's explicit entries. There is permission check so you must call this method from a safe block.
 	    /// </summary>
 	    /// <param name="contentId">Id of the content.</param>
 	    /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
@@ -809,7 +809,7 @@ namespace SenseNet.ContentRepository.Storage.Security
 	    }
 
         /// <summary>
-        /// Returns the current content's effective normal entries. Current user must have SeePermissions permission.
+        /// Returns the current content's effective entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="entryType">Security entry type. Default: all entries.</param>
         public List<AceInfo> GetEffectiveEntries(EntryType? entryType = null)
@@ -817,7 +817,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             return GetEffectiveEntries(_node.Id, null, entryType);
         }
         /// <summary>
-        /// Return with the passed content's effective entries. Current user must have SeePermissions permission.
+        /// Return the passed content's effective entries. Current user must have SeePermissions permission.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>
@@ -828,7 +828,7 @@ namespace SenseNet.ContentRepository.Storage.Security
             return SecurityContext.GetEffectiveEntries(contentId, relatedIdentities, entryType);
         }
         /// <summary>
-        /// Return with the passed content's effective entries. There is permission check so you must call this method from a safe block.
+        /// Return the passed content's effective entries. There is permission check so you must call this method from a safe block.
         /// </summary>
         /// <param name="contentId">Id of the content.</param>
         /// <param name="relatedIdentities">If not passed, the current user's related identities is focused.</param>

--- a/src/Storage/Security/SecurityHandler.cs
+++ b/src/Storage/Security/SecurityHandler.cs
@@ -779,12 +779,11 @@ namespace SenseNet.ContentRepository.Storage.Security
         }
 
         /// <summary>
-        /// Return with the current content's explicit entries. Current user must have SeePermissions permission.
+        /// Returns the current content's explicit normal entries. Current user must have SeePermissions permission.
         /// </summary>
-        /// <param name="entryType">Security entry type. Default: all entries.</param>
-        public List<AceInfo> GetExplicitEntries(EntryType? entryType = null)
+        public List<AceInfo> GetExplicitEntries()
         {
-            return GetExplicitEntries(_node.Id, null, entryType);
+            return GetExplicitEntries(_node.Id, null, EntryType.Normal);
         }
         /// <summary>
         /// Return with the passed content's explicit entries. Current user must have SeePermissions permission.
@@ -809,12 +808,11 @@ namespace SenseNet.ContentRepository.Storage.Security
 	    }
 
         /// <summary>
-        /// Return with the current content's effective entries. Current user must have SeePermissions permission.
+        /// Returns the current content's effective normal entries. Current user must have SeePermissions permission.
         /// </summary>
-        /// <param name="entryType">Security entry type. Default: all entries.</param>
-        public List<AceInfo> GetEffectiveEntries(EntryType? entryType = null)
+        public List<AceInfo> GetEffectiveEntries()
         {
-            return GetEffectiveEntries(_node.Id, null, entryType);
+            return GetEffectiveEntries(_node.Id, null, EntryType.Normal);
         }
         /// <summary>
         /// Return with the passed content's effective entries. Current user must have SeePermissions permission.

--- a/src/Tests/SenseNet.ContentRepository.Tests/SharingTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/SharingTests.cs
@@ -499,7 +499,7 @@ namespace SenseNet.ContentRepository.Tests
                 try
                 {
                     Assert.AreEqual(0, content.Sharing.Items.Count());
-                    Assert.AreEqual(0, content.Sharing.GetExplicitEntries().Count);
+                    Assert.AreEqual(0, content.Sharing.GetExplicitSharingEntries().Count);
 
                     var xDoc = new XmlDocument();
                     xDoc.LoadXml(importData1);
@@ -531,7 +531,7 @@ namespace SenseNet.ContentRepository.Tests
                     Assert.AreEqual(0, sd3.Identity);
                     Assert.AreEqual(SharingMode.Authenticated, sd3.Mode);
 
-                    var permEntries = content.Sharing.GetExplicitEntries();
+                    var permEntries = content.Sharing.GetExplicitSharingEntries();
                     var userEntry = permEntries.Single(pe => pe.IdentityId == user.Id);
                     var everyoneEntry = permEntries.Single(pe => pe.IdentityId == Identifiers.EveryoneGroupId);
 
@@ -570,7 +570,7 @@ namespace SenseNet.ContentRepository.Tests
 </Sharing></Fields>";
 
                 Assert.AreEqual(0, content.Sharing.Items.Count());
-                Assert.AreEqual(0, content.Sharing.GetExplicitEntries().Count);
+                Assert.AreEqual(0, content.Sharing.GetExplicitSharingEntries().Count);
 
                 var xDoc = new XmlDocument();
                 xDoc.LoadXml(importData1);
@@ -588,7 +588,7 @@ namespace SenseNet.ContentRepository.Tests
                 // unknown identity in the import xml
                 Assert.AreEqual(0, sd1.Identity);
 
-                var permEntries = content.Sharing.GetExplicitEntries();
+                var permEntries = content.Sharing.GetExplicitSharingEntries();
 
                 Assert.AreEqual(0, permEntries.Count);
 
@@ -611,7 +611,7 @@ namespace SenseNet.ContentRepository.Tests
                 
                 Assert.AreEqual(user.Id, sd1.Identity);
 
-                permEntries = content.Sharing.GetExplicitEntries();
+                permEntries = content.Sharing.GetExplicitSharingEntries();
                 var userEntry = permEntries.Single(pe => pe.IdentityId == user.Id);
 
                 Assert.IsTrue(userEntry.GetPermissionValues()[4] == PermissionValue.Allowed);
@@ -843,7 +843,7 @@ namespace SenseNet.ContentRepository.Tests
                 Assert.AreEqual(user3.Id, sd3.Identity);
 
                 // check for new permissions too
-                var aceList = root.Sharing.GetExplicitEntries();
+                var aceList = root.Sharing.GetExplicitSharingEntries();
                 Assert.IsNull(aceList.SingleOrDefault(ace => ace.IdentityId == user1.Id), "The user got unnecessary permissions.");
                 Assert.IsNull(aceList.SingleOrDefault(ace => ace.IdentityId == user2.Id), "The user got unnecessary permissions.");
                 Assert.IsNotNull(aceList.SingleOrDefault(ace => ace.IdentityId == user3.Id), "The user did not get the necessary permission.");
@@ -1074,8 +1074,8 @@ namespace SenseNet.ContentRepository.Tests
                 var g1 = groups[0]; // open
                 var g2 = groups[1]; // edit
 
-                var acei1 = content.Sharing.GetExplicitEntries().Single(acei => acei.IdentityId == g1.Id);
-                var acei2 = content.Sharing.GetExplicitEntries().Single(acei => acei.IdentityId == g2.Id);
+                var acei1 = content.Sharing.GetExplicitSharingEntries().Single(acei => acei.IdentityId == g1.Id);
+                var acei2 = content.Sharing.GetExplicitSharingEntries().Single(acei => acei.IdentityId == g2.Id);
 
                 // group1: Open
                 Assert.AreEqual("Open", (string)g1["SharingLevelValue"]);
@@ -1306,13 +1306,13 @@ namespace SenseNet.ContentRepository.Tests
 
                 // ACTION
                 gc.Sharing.Share("abc1@example.com", SharingLevel.Open, SharingMode.Public);
-                var entries1 = gc.Sharing.GetExplicitEntries();
+                var entries1 = gc.Sharing.GetExplicitSharingEntries();
 
                 gc.Sharing.Share("abc2@example.com", SharingLevel.Open, SharingMode.Authenticated);
-                var entries2 = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToList();
+                var entries2 = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToList();
 
                 gc.Sharing.Share(user1.Email, SharingLevel.Edit, SharingMode.Private);
-                var entries3 = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToList();
+                var entries3 = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToList();
 
                 // ASSERT
                 Assert.AreEqual(1, entries1.Count);
@@ -1350,9 +1350,9 @@ namespace SenseNet.ContentRepository.Tests
 
                 // ACTION
                 gc.Sharing.Share(user1.Email, SharingLevel.Open, SharingMode.Private);
-                var entries1 = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToList();
+                var entries1 = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToList();
                 gc.Sharing.Share(user1.Email, SharingLevel.Edit, SharingMode.Private);
-                var entries2 = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToList();
+                var entries2 = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToList();
 
                 // ASSERT
                 Assert.AreEqual(1, entries1.Count);
@@ -1393,7 +1393,7 @@ namespace SenseNet.ContentRepository.Tests
                     sharing.Take(4).Select(x => x.Token),
                     gc.Sharing.Items.OrderBy(x => x.Token).Select(x => x.Token));
 
-                var entries = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToArray();
+                var entries = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToArray();
                 Assert.AreEqual(2, entries.Length);
                 // everyone group
                 Assert.AreEqual(Identifiers.EveryoneGroupId, entries[0].IdentityId);
@@ -1410,7 +1410,7 @@ namespace SenseNet.ContentRepository.Tests
                     sharing.Take(3).Select(x => x.Token),
                     gc.Sharing.Items.OrderBy(x => x.Token).Select(x => x.Token));
 
-                entries = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToArray();
+                entries = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToArray();
                 Assert.AreEqual(2, entries.Length);
                 // everyone group
                 Assert.AreEqual(Identifiers.EveryoneGroupId, entries[0].IdentityId);
@@ -1427,7 +1427,7 @@ namespace SenseNet.ContentRepository.Tests
                     sharing.Take(2).Select(x => x.Token),
                     gc.Sharing.Items.OrderBy(x => x.Token).Select(x => x.Token));
 
-                entries = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).ToArray();
+                entries = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).ToArray();
                 Assert.AreEqual(2, entries.Length);
                 // everyone group
                 Assert.AreEqual(Identifiers.EveryoneGroupId, entries[0].IdentityId);
@@ -1444,7 +1444,7 @@ namespace SenseNet.ContentRepository.Tests
                     sharing.Take(1).Select(x => x.Token),
                     gc.Sharing.Items.OrderBy(x => x.Token).Select(x => x.Token));
 
-                entries = gc.Sharing.GetExplicitEntries().ToArray();
+                entries = gc.Sharing.GetExplicitSharingEntries().ToArray();
                 Assert.AreEqual(1, entries.Length);
                 // user
                 Assert.AreEqual(user1.Id, entries[0].IdentityId);
@@ -1473,8 +1473,8 @@ namespace SenseNet.ContentRepository.Tests
                 };
 
                 // ACTION
-                var securityEntries = gc.Security.GetExplicitEntries().OrderBy(e=>e.IdentityId).Select(e => e.ToString());
-                var sharingEntries = gc.Sharing.GetExplicitEntries().OrderBy(e => e.IdentityId).Select(e => e.ToString());
+                var securityEntries = gc.Security.GetExplicitEntries(EntryType.Normal).OrderBy(e=>e.IdentityId).Select(e => e.ToString());
+                var sharingEntries = gc.Sharing.GetExplicitSharingEntries().OrderBy(e => e.IdentityId).Select(e => e.ToString());
 
                 // ASSERT
                 AssertSequenceEqual(new[]
@@ -1511,8 +1511,8 @@ namespace SenseNet.ContentRepository.Tests
                 };
 
                 // ACTION
-                var securityEntries = gc.Security.GetEffectiveEntries().OrderBy(e => e.IdentityId).Select(e=>e.ToString());
-                var sharingEntries = gc.Sharing.GetEffectiveEntries().OrderBy(e => e.IdentityId).Select(e => e.ToString());
+                var securityEntries = gc.Security.GetEffectiveEntries(EntryType.Normal).OrderBy(e => e.IdentityId).Select(e=>e.ToString());
+                var sharingEntries = gc.Sharing.GetEffectiveSharingEntries().OrderBy(e => e.IdentityId).Select(e => e.ToString());
 
                 // ASSERT
                 AssertSequenceEqual(new[]
@@ -1704,7 +1704,7 @@ namespace SenseNet.ContentRepository.Tests
 
             try
             {
-                e2 = content.Sharing.GetExplicitEntries().Any(ace => ace.IdentityId == group.Id);
+                e2 = content.Sharing.GetExplicitSharingEntries().Any(ace => ace.IdentityId == group.Id);
             }
             catch (EntityNotFoundException)
             {


### PR DESCRIPTION
Do NOT merge yet.

We have to decide:
- where to work with only _Normal_ permission entries and where to load all types
- how we should extend the API to reflect this
- tests should be green