### PR TITLE
More permissive Content Type system

### DIFF
--- a/src/ContentRepository/ISnComponent.cs
+++ b/src/ContentRepository/ISnComponent.cs
@@ -34,5 +34,19 @@ namespace SenseNet.ContentRepository
         /// <param name="componentVersion">The currently installed version of the component.</param>
         /// <returns>True if the assembly and component versions are compatible.</returns>
         bool IsComponentAllowed(Version componentVersion);
+
+        SnPatch[] Patches { get; }
+    }
+
+    public class SnPatch
+    {
+        public Version Version { get; set; }
+        public Version MinVersion { get; set; }
+        public Version MaxVersion { get; set; }
+        public bool MinVersionIsExclusive { get; set; }
+        public bool MaxVersionIsExclusive { get; set; }
+
+        //UNDONE: finalize patch definition options (resource, code, Manifest object)
+        public string Contents { get; set; }
     }
 }

--- a/src/ContentRepository/ISnComponent.cs
+++ b/src/ContentRepository/ISnComponent.cs
@@ -36,6 +36,7 @@ namespace SenseNet.ContentRepository
         /// <returns>True if the assembly and component versions are compatible.</returns>
         bool IsComponentAllowed(Version componentVersion);
 
-        SnPatch[] Patches { get; }
+        //UNDONE: [auto-patch] this feature is not released yet
+        //SnPatch[] Patches { get; }
     }
 }

--- a/src/ContentRepository/ISnComponent.cs
+++ b/src/ContentRepository/ISnComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SenseNet.ContentRepository.Storage;
 
 namespace SenseNet.ContentRepository
 {
@@ -48,5 +49,7 @@ namespace SenseNet.ContentRepository
 
         //UNDONE: finalize patch definition options (resource, code, Manifest object)
         public string Contents { get; set; }
+
+        public Func<RepositoryStartSettings, ExecutionResult> Execute;
     }
 }

--- a/src/ContentRepository/ISnComponent.cs
+++ b/src/ContentRepository/ISnComponent.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using SenseNet.ContentRepository.Storage;
+using SenseNet.Packaging;
 
 namespace SenseNet.ContentRepository
 {
@@ -37,19 +37,5 @@ namespace SenseNet.ContentRepository
         bool IsComponentAllowed(Version componentVersion);
 
         SnPatch[] Patches { get; }
-    }
-
-    public class SnPatch
-    {
-        public Version Version { get; set; }
-        public Version MinVersion { get; set; }
-        public Version MaxVersion { get; set; }
-        public bool MinVersionIsExclusive { get; set; }
-        public bool MaxVersionIsExclusive { get; set; }
-
-        //UNDONE: finalize patch definition options (resource, code, Manifest object)
-        public string Contents { get; set; }
-
-        public Func<RepositoryStartSettings, ExecutionResult> Execute;
     }
 }

--- a/src/ContentRepository/Packaging/ExecutionContext.cs
+++ b/src/ContentRepository/Packaging/ExecutionContext.cs
@@ -62,7 +62,7 @@ namespace SenseNet.Packaging
             this.Manifest = manifest;
             this.CurrentPhase = currentPhase;
             this.CountOfPhases = countOfPhases;
-            this.Console = console;
+            this.Console = console ?? TextWriter.Null;
 
             if (manifest == null)
                 return;
@@ -77,12 +77,17 @@ namespace SenseNet.Packaging
                 SetVariable(name, value ?? defaultValue);
             }
         }
-        internal static ExecutionContext CreateForTest(string packagePath, string targetPath, string[] networkTargets, string sandboxPath, Manifest manifest, int currentPhase, int countOfPhases, string[] parameters, TextWriter console, RepositoryStartSettings settings = null)
+        internal static ExecutionContext CreateForTest(string packagePath, string targetPath, string[] networkTargets, string sandboxPath, Manifest manifest, int currentPhase, int countOfPhases, string[] parameters, TextWriter console)
+        {
+            var packageParameters = parameters?.Select(PackageParameter.Parse).ToArray() ?? new PackageParameter[0];
+            return new ExecutionContext(packagePath, targetPath, networkTargets, sandboxPath, manifest, currentPhase, countOfPhases, packageParameters, console) { Test = true };
+        }
+        internal static ExecutionContext Create(string packagePath, string targetPath, string[] networkTargets, string sandboxPath, Manifest manifest, int currentPhase, int countOfPhases, string[] parameters, TextWriter console, RepositoryStartSettings settings)
         {
             var packageParameters = parameters?.Select(PackageParameter.Parse).ToArray() ?? new PackageParameter[0];
             return new ExecutionContext(packagePath, targetPath, networkTargets, sandboxPath, manifest, currentPhase, countOfPhases, packageParameters, console)
             {
-                Test = true, 
+                Test = false,
                 RepositoryStartSettings = settings
             };
         }

--- a/src/ContentRepository/Packaging/ExecutionContext.cs
+++ b/src/ContentRepository/Packaging/ExecutionContext.cs
@@ -48,6 +48,7 @@ namespace SenseNet.Packaging
         /// <summary>True if the StartRepository step has already executed.</summary>
         public bool RepositoryStarted { get; internal set; }
         internal bool Test { get; set; }
+        internal RepositoryStartSettings RepositoryStartSettings { get; set; }
 
         /// <summary>
         /// DO NOT USE THIS CONSTRUCTOR FROM TESTS. Use ExecutionContext.CreateForTest method instead.
@@ -76,10 +77,14 @@ namespace SenseNet.Packaging
                 SetVariable(name, value ?? defaultValue);
             }
         }
-        internal static ExecutionContext CreateForTest(string packagePath, string targetPath, string[] networkTargets, string sandboxPath, Manifest manifest, int currentPhase, int countOfPhases, string[] parameters, TextWriter console)
+        internal static ExecutionContext CreateForTest(string packagePath, string targetPath, string[] networkTargets, string sandboxPath, Manifest manifest, int currentPhase, int countOfPhases, string[] parameters, TextWriter console, RepositoryStartSettings settings = null)
         {
             var packageParameters = parameters?.Select(PackageParameter.Parse).ToArray() ?? new PackageParameter[0];
-            return new ExecutionContext(packagePath, targetPath, networkTargets, sandboxPath, manifest, currentPhase, countOfPhases, packageParameters, console) { Test = true };
+            return new ExecutionContext(packagePath, targetPath, networkTargets, sandboxPath, manifest, currentPhase, countOfPhases, packageParameters, console)
+            {
+                Test = true, 
+                RepositoryStartSettings = settings
+            };
         }
 
         /// <summary>Verifies that the Repository is running and throws an exception if not.</summary>

--- a/src/ContentRepository/Packaging/PackageManager.cs
+++ b/src/ContentRepository/Packaging/PackageManager.cs
@@ -379,6 +379,14 @@ namespace SenseNet.Packaging
 
                         continue;
                     }
+                    if (!string.IsNullOrEmpty(patch.Contents) && patch.Execute != null)
+                    {
+                        // ambigous patch definition
+                        SnLog.WriteWarning(
+                            $"Patch {patch.Version} for component {assemblyComponent.ComponentId} cannot be executed because it contains multiple patch definitions.");
+
+                        continue;
+                    }
 
                     // check if the patch is relevant for the currently installed component version
                     if (patch.MinVersion > installedComponent.Version ||

--- a/src/ContentRepository/Packaging/PackageManager.cs
+++ b/src/ContentRepository/Packaging/PackageManager.cs
@@ -323,6 +323,9 @@ namespace SenseNet.Packaging
         public static Dictionary<string, Dictionary<Version, PackagingResult>> ExecuteAssemblyPatches(
             RepositoryStartSettings settings = null)
         {
+            //UNDONE: make sure that patches are executed exclusively 
+            // No other app domain should be able to start executing patches.
+
             return ExecuteAssemblyPatches(RepositoryVersionInfo.GetAssemblyComponents(), settings);
         }
 

--- a/src/ContentRepository/Packaging/PackageManager.cs
+++ b/src/ContentRepository/Packaging/PackageManager.cs
@@ -367,7 +367,7 @@ namespace SenseNet.Packaging
                         continue;
 
                     //UNDONE: handle other patch formats (resource or filesystem path)
-                    if (patch.Contents.StartsWith("<?xml", StringComparison.InvariantCultureIgnoreCase))
+                    if (patch.Contents?.StartsWith("<?xml", StringComparison.InvariantCultureIgnoreCase) ?? false)
                     {
                         var patchResult = ExecutePatch(patch.Contents, console, settings);
                         patchResults[patch.Version] = patchResult;
@@ -377,6 +377,10 @@ namespace SenseNet.Packaging
                             throw new PackagingException(
                                 $"Package execution failed for component {assemblyComponent.ComponentId}. Patch target version: {patch.Version}.");
                         }
+                    }
+                    else
+                    {
+                        patch.Execute?.Invoke(settings);
                     }
 
                     // reload

--- a/src/ContentRepository/Packaging/PackageManager.cs
+++ b/src/ContentRepository/Packaging/PackageManager.cs
@@ -320,7 +320,7 @@ namespace SenseNet.Packaging
         /// <returns>Package execution results grouped by component id. It may contain multiple
         /// results for a single component if there are multiple patches in the assembly for
         /// subsequent component versions.</returns>
-        public static Dictionary<string, Dictionary<Version, PackagingResult>> ExecuteAssemblyPatches(
+        internal static Dictionary<string, Dictionary<Version, PackagingResult>> ExecuteAssemblyPatches(
             RepositoryStartSettings settings = null)
         {
             //UNDONE: make sure that patches are executed exclusively 

--- a/src/ContentRepository/Packaging/SnPatch.cs
+++ b/src/ContentRepository/Packaging/SnPatch.cs
@@ -6,15 +6,25 @@ namespace SenseNet.Packaging
 {
     public class SnPatch
     {
+        /// <summary>
+        /// Patch target version.
+        /// </summary>
         public Version Version { get; set; }
         public Version MinVersion { get; set; }
         public Version MaxVersion { get; set; }
         public bool MinVersionIsExclusive { get; set; }
         public bool MaxVersionIsExclusive { get; set; }
 
-        //UNDONE: finalize patch definition options (resource, code, Manifest object)
+        //TODO: add more patch definition options (resource, code, Manifest object)
+
+        /// <summary>
+        /// Patch definition in a manifest xml format.
+        /// </summary>
         public string Contents { get; set; }
 
+        /// <summary>
+        /// Patch definition in the form of code.
+        /// </summary>
         public Func<PatchContext, ExecutionResult> Execute;
     }
 

--- a/src/ContentRepository/Packaging/SnPatch.cs
+++ b/src/ContentRepository/Packaging/SnPatch.cs
@@ -4,6 +4,12 @@ using SenseNet.ContentRepository.Storage;
 
 namespace SenseNet.Packaging
 {
+    /// <summary>
+    /// Represents a patch that will be executed only if the current component version
+    /// is lower than the supported version of the component and it is between the defined 
+    /// minimum and maximum version numbers in this patch. The component version after 
+    /// this patch will be the one defined in the Version property.
+    /// </summary>
     public class SnPatch
     {
         /// <summary>
@@ -12,7 +18,18 @@ namespace SenseNet.Packaging
         public Version Version { get; set; }
         public Version MinVersion { get; set; }
         public Version MaxVersion { get; set; }
+
+        /// <summary>
+        /// If set to true, the patch will not be executed if the current
+        /// component version is the same as the minimum version defined
+        /// in this patch.
+        /// </summary>
         public bool MinVersionIsExclusive { get; set; }
+        /// <summary>
+        /// If set to true, the patch will not be executed if the current
+        /// component version is the same as the maximum version defined
+        /// in this patch.
+        /// </summary>
         public bool MaxVersionIsExclusive { get; set; }
 
         //TODO: add more patch definition options (resource, code, Manifest object)

--- a/src/ContentRepository/Packaging/SnPatch.cs
+++ b/src/ContentRepository/Packaging/SnPatch.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Storage;
+
+namespace SenseNet.Packaging
+{
+    public class SnPatch
+    {
+        public Version Version { get; set; }
+        public Version MinVersion { get; set; }
+        public Version MaxVersion { get; set; }
+        public bool MinVersionIsExclusive { get; set; }
+        public bool MaxVersionIsExclusive { get; set; }
+
+        //UNDONE: finalize patch definition options (resource, code, Manifest object)
+        public string Contents { get; set; }
+
+        public Func<PatchContext, ExecutionResult> Execute;
+    }
+
+    public class PatchContext
+    {
+        public RepositoryStartSettings Settings { get; set; }
+    }
+}

--- a/src/ContentRepository/Packaging/Steps/StartRepository.cs
+++ b/src/ContentRepository/Packaging/Steps/StartRepository.cs
@@ -52,14 +52,16 @@ namespace SenseNet.Packaging.Steps
             Logger.LogMessage("startIndexingEngine: " + startIndexingEngine);
             Logger.LogMessage("indexPath: " + indexPath);
 
-            Repository.Start(new RepositoryStartSettings
+            var startSettings = context.RepositoryStartSettings ?? new RepositoryStartSettings
             {
                 StartIndexingEngine = startIndexingEngine,
                 PluginsPath = PluginsPath ?? context.SandboxPath,
                 IndexPath = indexPath,
                 StartWorkflowEngine = StartWorkflowEngine,
                 Console = context.Console
-            });
+            };
+
+            Repository.Start(startSettings);
 
             context.Console.WriteLine("Ok.");
 

--- a/src/ContentRepository/Repository.cs
+++ b/src/ContentRepository/Repository.cs
@@ -3,6 +3,7 @@ using SenseNet.ContentRepository.Storage;
 using SenseNet.ContentRepository.Storage.Security;
 using SenseNet.Configuration;
 using SenseNet.Tools;
+using SenseNet.Packaging;
 
 namespace SenseNet.ContentRepository
 {
@@ -52,6 +53,15 @@ namespace SenseNet.ContentRepository
         /// <returns></returns>
         public static RepositoryInstance Start(RepositoryStartSettings settings)
         {
+            if (!settings.ExecutingPatches)
+            {
+                // Switch ON this flag so that inner repository start operations
+                // do not try to execute patches again recursively.
+                settings.ExecutingPatches = true;
+
+                PackageManager.ExecuteAssemblyPatches(settings.Console, settings);
+            }
+
             var instance = RepositoryInstance.Start(settings);
             SystemAccount.Execute(() => Root);
             return instance;

--- a/src/ContentRepository/Repository.cs
+++ b/src/ContentRepository/Repository.cs
@@ -59,7 +59,8 @@ namespace SenseNet.ContentRepository
                 // do not try to execute patches again recursively.
                 settings.ExecutingPatches = true;
 
-                PackageManager.ExecuteAssemblyPatches(settings);
+                //UNDONE: [auto-patch] this feature is not released yet
+                //PackageManager.ExecuteAssemblyPatches(settings);
             }
 
             var instance = RepositoryInstance.Start(settings);

--- a/src/ContentRepository/Repository.cs
+++ b/src/ContentRepository/Repository.cs
@@ -59,7 +59,7 @@ namespace SenseNet.ContentRepository
                 // do not try to execute patches again recursively.
                 settings.ExecutingPatches = true;
 
-                PackageManager.ExecuteAssemblyPatches(settings.Console, settings);
+                PackageManager.ExecuteAssemblyPatches(settings);
             }
 
             var instance = RepositoryInstance.Start(settings);

--- a/src/ContentRepository/RepositoryStartSettings.cs
+++ b/src/ContentRepository/RepositoryStartSettings.cs
@@ -20,6 +20,7 @@ namespace SenseNet.ContentRepository
         public class ImmutableRepositoryStartSettings : RepositoryStartSettings
         {
             public new bool IsWebContext { get; }
+            public new bool ExecutingPatches { get; internal set; }
 
             /// <summary>
             /// Gets a value that is 'true' if your tool uses the Content search and any modification features (e.g. save, move etc.). 'True' is the default.
@@ -55,6 +56,7 @@ namespace SenseNet.ContentRepository
             internal ImmutableRepositoryStartSettings(RepositoryStartSettings settings)
             {
                 IsWebContext = settings.IsWebContext;
+                ExecutingPatches = settings.ExecutingPatches;
                 StartIndexingEngine = settings.StartIndexingEngine;
                 StartWorkflowEngine = settings.StartWorkflowEngine;
                 Console = settings.Console;
@@ -68,6 +70,7 @@ namespace SenseNet.ContentRepository
         internal static readonly RepositoryStartSettings Default = new RepositoryStartSettings();
 
         public virtual bool IsWebContext { get; set; } = false;
+        public virtual bool ExecutingPatches { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value that is 'true' if your tool uses the Content search and any modification features (e.g. save, move etc.). 'True' is the default.

--- a/src/ContentRepository/Schema/ContentType.cs
+++ b/src/ContentRepository/Schema/ContentType.cs
@@ -411,6 +411,10 @@ namespace  SenseNet.ContentRepository.Schema
             this.ParentTypeName = contentTypeElement.GetAttribute("parentType", String.Empty);
 
             this.IsUnknownHandler = TypeResolver.GetType(this.HandlerName, false) == null;
+            if (this.IsUnknownHandler)
+            {
+                SnLog.WriteWarning($"Unknown content handler {this.HandlerName} for content type {this.Name}.");
+            }
 
             if (this.ParentTypeName.Length == 0)
                 this.ParentTypeName = null;
@@ -514,8 +518,12 @@ namespace  SenseNet.ContentRepository.Schema
                 }
                 catch (ContentRegistrationException ex)
                 {
-                    SnLog.WriteWarning($"Unknown field type {fieldElement.GetAttribute("type", string.Empty)} " +
-                                       $"for field {ex.FieldName} in content type {this.Name}.");
+                    SnLog.WriteWarning(
+                        $"Error during registration of field {ex.FieldName} in content type {this.Name}.",
+                        properties: new Dictionary<string, object>
+                        {
+                            {"FieldXml", fieldElement.OuterXml}
+                        });
 
                     // continue building the content type without breaking the whole system
                     this.HasUnknownField = true;

--- a/src/ContentRepository/Schema/ContentTypeInstaller.cs
+++ b/src/ContentRepository/Schema/ContentTypeInstaller.cs
@@ -114,6 +114,14 @@ namespace SenseNet.ContentRepository.Schema
         {
             var contentType = ContentTypeManager.LoadOrCreateNew(ctd.Document);
 
+            if (contentType.IsInvalid)
+            {
+                // registering a content type with an invalid handler or field is not allowed
+                throw new ContentRegistrationException(
+                    $"Error during installing content type {contentType.Name}. Please check the log for " +
+                    "a registration error or warning.");
+            }
+
             // skip notification during content type install to avoid missing field errors
             contentType.DisableObserver(TypeResolver.GetType(NodeObserverNames.NOTIFICATION, false));
 

--- a/src/ContentRepository/Schema/ContentTypeManager.cs
+++ b/src/ContentRepository/Schema/ContentTypeManager.cs
@@ -88,14 +88,16 @@ namespace SenseNet.ContentRepository.Schema
                 var contentTypeNamesByType = new Dictionary<Type, NodeType>();
                 foreach (var nt in ActiveSchema.NodeTypes)
                 {
-                    var type = TypeResolver.GetType(nt.ClassName);
-                    NodeType prevNt;
+                    var type = TypeResolver.GetType(nt.ClassName, false);
+                    if (type == null)
+                        continue;
+
                     if (type == typeof(GenericContent))
                     {
                         if (nt.Name == "GenericContent")
                             contentTypeNamesByType.Add(type, nt);
                     }
-                    else if (!contentTypeNamesByType.TryGetValue(type, out prevNt))
+                    else if (!contentTypeNamesByType.TryGetValue(type, out var prevNt))
                         contentTypeNamesByType.Add(type, nt);
                     else
                         if (prevNt.IsInstaceOfOrDerivedFrom(nt))
@@ -103,9 +105,10 @@ namespace SenseNet.ContentRepository.Schema
                 }
                 Instance._contentTypeNamesByType = contentTypeNamesByType;
             }
-            NodeType nodeType;
-            if (Instance._contentTypeNamesByType.TryGetValue(t, out nodeType))
+
+            if (Instance._contentTypeNamesByType.TryGetValue(t, out var nodeType))
                 return nodeType.Name;
+
             return null;
         }
         #endregion
@@ -350,6 +353,17 @@ namespace SenseNet.ContentRepository.Schema
                 parentNodeType = editor.NodeTypes[contentType.ParentTypeName];
                 if (parentNodeType == null)
                     throw new ContentRegistrationException(SR.Exceptions.Registration.Msg_UnknownParentContentType, contentType.Name);
+
+                // make sure that all content handlers defined on the parent chain exist
+                var pnt = parentNodeType;
+                while (pnt != null)
+                {
+                    var ht = TypeResolver.GetType(pnt.ClassName, false);
+                    if (ht == null)
+                        throw new RegistrationException($"Unknown content handler: {pnt.ClassName}");
+
+                    pnt = pnt.Parent;
+                }
             }
 
             // handler type

--- a/src/ContentRepository/Schema/FieldDescriptor.cs
+++ b/src/ContentRepository/Schema/FieldDescriptor.cs
@@ -44,13 +44,28 @@ namespace SenseNet.ContentRepository.Schema
             fdesc.FieldTypeName = fieldElement.GetAttribute("handler", String.Empty);
             fdesc.IsContentListField = fdesc.FieldName[0] == '#';
             if (String.IsNullOrEmpty(fdesc.FieldTypeShortName))
+            {
                 fdesc.FieldTypeShortName = FieldManager.GetShortName(fdesc.FieldTypeName);
+
+                if (string.IsNullOrEmpty(fdesc.FieldTypeShortName))
+                    throw new ContentRegistrationException($"Unknown field handler: {fdesc.FieldTypeName}", null,
+                        contentType.Name, fieldName);
+            }
 
             if (fdesc.FieldTypeName.Length == 0)
             {
                 if (fdesc.FieldTypeShortName.Length == 0)
                     throw new ContentRegistrationException("Field element's 'handler' attribute is required if 'type' attribute is not given.", contentType.Name, fdesc.FieldName);
-                fdesc.FieldTypeName = FieldManager.GetFieldHandlerName(fdesc.FieldTypeShortName);
+
+                try
+                {
+                    fdesc.FieldTypeName = FieldManager.GetFieldHandlerName(fdesc.FieldTypeShortName);
+                }
+                catch (NotSupportedException ex)
+                {
+                    throw new ContentRegistrationException($"Unknown field type: {fdesc.FieldTypeShortName}", ex,
+                        contentType.Name, fieldName);
+                }
             }
 
             fdesc.Bindings = new List<string>();

--- a/src/ContentRepository/Schema/UnknownContentHandler.cs
+++ b/src/ContentRepository/Schema/UnknownContentHandler.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using SenseNet.ContentRepository.Schema;
+using SenseNet.ContentRepository.Storage;
+
+namespace SenseNet.Storage
+{
+    [ContentHandler]
+    public class UnknownContentHandler : Node
+    {
+        public UnknownContentHandler(Node parent) : this(parent, null) { }
+        public UnknownContentHandler(Node parent, string nodeTypeName) : base(parent, nodeTypeName) { }
+        protected UnknownContentHandler(NodeToken nt) : base(nt) { }
+        public override bool IsContentType { get; } = false;
+
+        public override void Save(NodeSaveSettings settings)
+        {
+            ThrowException("save");
+        }
+        public override void CopyTo(Node target)
+        {
+            ThrowException("copy");
+        }
+        public override void CopyTo(Node target, string newName)
+        {
+            ThrowException("copy");
+        }
+        public override void Delete()
+        {
+            ThrowException("delete");
+        }
+        public override void FinalizeContent()
+        {
+            ThrowException("finalize");
+        }
+        public override void ForceDelete()
+        {
+            ThrowException("delete");
+        }
+        public override void MoveTo(Node target)
+        {
+            ThrowException("move");
+        }
+
+        private static void ThrowException(string operation)
+        {
+            throw new SnNotSupportedException($"Cannot {operation} a content with an unknown handler.");
+        }
+    }
+}

--- a/src/ContentRepository/SnComponent.cs
+++ b/src/ContentRepository/SnComponent.cs
@@ -19,5 +19,7 @@ namespace SenseNet.ContentRepository
         {
             return true;
         }
+
+        public SnPatch[] Patches { get; } = new SnPatch[0];
     }
 }

--- a/src/ContentRepository/SnComponent.cs
+++ b/src/ContentRepository/SnComponent.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using SenseNet.ContentRepository.Storage;
+using SenseNet.Packaging;
 
 namespace SenseNet.ContentRepository
 {

--- a/src/ContentRepository/SnComponentInfo.cs
+++ b/src/ContentRepository/SnComponentInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SenseNet.ContentRepository.Storage;
+using SenseNet.Packaging;
 
 namespace SenseNet.ContentRepository
 {

--- a/src/ContentRepository/SnComponentInfo.cs
+++ b/src/ContentRepository/SnComponentInfo.cs
@@ -24,7 +24,8 @@ namespace SenseNet.ContentRepository
                 SupportedVersion = component.SupportedVersion ?? asmVersion,
                 AssemblyVersion = asmVersion,
                 IsComponentAllowed = component.IsComponentAllowed,
-                Patches = component.Patches
+                //UNDONE: [auto-patch] this feature is not released yet
+                //Patches = component.Patches
             };
         }
     }

--- a/src/ContentRepository/SnComponentInfo.cs
+++ b/src/ContentRepository/SnComponentInfo.cs
@@ -9,6 +9,7 @@ namespace SenseNet.ContentRepository
         public Version AssemblyVersion { get; set; }
         public Version SupportedVersion { get; set; }
         public Func<Version, bool> IsComponentAllowed { get; set; }
+        public SnPatch[] Patches { get; set; }
 
         public static SnComponentInfo Create(ISnComponent component)
         {
@@ -21,7 +22,8 @@ namespace SenseNet.ContentRepository
                 ComponentId = component.ComponentId,
                 SupportedVersion = component.SupportedVersion ?? asmVersion,
                 AssemblyVersion = asmVersion,
-                IsComponentAllowed = component.IsComponentAllowed
+                IsComponentAllowed = component.IsComponentAllowed,
+                Patches = component.Patches
             };
         }
     }

--- a/src/Services/ApplicationModel/HttpAction.cs
+++ b/src/Services/ApplicationModel/HttpAction.cs
@@ -45,8 +45,8 @@ namespace SenseNet.Portal.AppModel
 
         private bool IsApplication(NodeHead appNode)
         {
-            var type = TypeResolver.GetType(appNode.GetNodeType().ClassName);
-            return typeof(Application).IsAssignableFrom(type);
+            var type = TypeResolver.GetType(appNode.GetNodeType().ClassName, false);
+            return type != null && typeof(Application).IsAssignableFrom(type);
         }
 
         public virtual bool CheckPermission()

--- a/src/Services/ApplicationModel/HttpActionManager.cs
+++ b/src/Services/ApplicationModel/HttpActionManager.cs
@@ -177,8 +177,8 @@ namespace SenseNet.Portal.AppModel
         private static IHttpAction GetIHttpHandlerAction(IHttpActionFactory factory, PortalContext portalContext, NodeHead contextNode, NodeHead handlerNode)
         {
             var nodeType = handlerNode.GetNodeType();
-            Type appType = TypeResolver.GetType(nodeType.ClassName);
-            if (typeof(IHttpHandler).IsAssignableFrom(appType))
+            Type appType = TypeResolver.GetType(nodeType.ClassName, false);
+            if (appType != null && typeof(IHttpHandler).IsAssignableFrom(appType))
                 return factory.CreateRemapAction(portalContext, contextNode, null, handlerNode);
             return null;
         }

--- a/src/Services/Virtualization/PortalContext.cs
+++ b/src/Services/Virtualization/PortalContext.cs
@@ -546,8 +546,8 @@ namespace SenseNet.Portal.Virtualization
             if (nodeType.IsInstaceOfOrDerivedFrom("Page"))
                 return true;
 
-            Type appType = TypeResolver.GetType(nodeType.ClassName);
-            return typeof(IHttpHandler).IsAssignableFrom(appType);
+            var appType = TypeResolver.GetType(nodeType.ClassName, false);
+            return appType != null && typeof(IHttpHandler).IsAssignableFrom(appType);
         }
 
         public static PortalContext Current

--- a/src/Storage/DataBackingStore.cs
+++ b/src/Storage/DataBackingStore.cs
@@ -632,8 +632,8 @@ namespace SenseNet.ContentRepository.Storage
             if (Cache.CacheContentAfterSaveMode != Cache.CacheContentAfterSaveOption.Containers)
                 return Cache.CacheContentAfterSaveMode == Cache.CacheContentAfterSaveOption.All;
             
-            var type = TypeResolver.GetType(nodeType.ClassName);
-            return typeof(IFolder).IsAssignableFrom(type);
+            var type = TypeResolver.GetType(nodeType.ClassName, false);
+            return type != null && typeof(IFolder).IsAssignableFrom(type);
         }
         private static bool IsDeadlockException(System.Data.Common.DbException e)
         {

--- a/src/Tests/SenseNet.ContentRepository.Tests/ContentTypeTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/ContentTypeTests.cs
@@ -51,6 +51,7 @@ namespace SenseNet.ContentRepository.Tests
 
         [TestMethod]
         [TestCategory("ContentType")]
+        [ExpectedException(typeof(ContentRegistrationException))]
         public void ContentType_WrongAnalyzer()
         {
             var contentTypeName = System.Reflection.MethodBase.GetCurrentMethod().Name;
@@ -61,10 +62,7 @@ namespace SenseNet.ContentRepository.Tests
                 var searchEngine = SearchManager.SearchEngine as InMemorySearchEngine;
                 Assert.IsNotNull(searchEngine);
 
-                string message = null;
-                try
-                {
-                    /**/ContentTypeInstaller.InstallContentType($@"<?xml version='1.0' encoding='utf-8'?>
+                /**/ContentTypeInstaller.InstallContentType($@"<?xml version='1.0' encoding='utf-8'?>
 <ContentType name='{contentTypeName}' parentType='GenericContent'
          handler='{typeof(GenericContent).FullName}' xmlns='http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition'>
     <Fields>
@@ -76,20 +74,6 @@ namespace SenseNet.ContentRepository.Tests
     </Fields>
 </ContentType>
 ");
-                    Assert.Fail("ContentRegistrationException was not thrown.");
-                }
-                catch (ContentRegistrationException e)
-                {
-                    message = e.Message;
-                }
-
-                Assert.IsNotNull(message);
-                Assert.IsTrue(message.Contains("Invalid analyzer"));
-                Assert.IsTrue(message.Contains(contentTypeName));
-                Assert.IsTrue(message.Contains(fieldName));
-                Assert.IsTrue(message.Contains(analyzerValue));
-
-                return true;
             });
         }
     }

--- a/src/Tests/SenseNet.ContentRepository.Tests/SenseNet.ContentRepository.Tests.csproj
+++ b/src/Tests/SenseNet.ContentRepository.Tests/SenseNet.ContentRepository.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="LoggerTests.cs" />
     <Compile Include="MaintenanceTests.cs" />
     <Compile Include="NodeTests.cs" />
+    <Compile Include="UnknownContentHandlerTests.cs" />
     <Compile Include="SharedLockTests.cs" />
     <Compile Include="SharingTests.cs" />
     <Compile Include="SharingVisitorTests.cs" />
@@ -172,6 +173,10 @@
     <ProjectReference Include="..\..\Storage\SenseNet.Storage.csproj">
       <Project>{5db4ddba-81f6-4d81-943a-18f3178b3355}</Project>
       <Name>SenseNet.Storage</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SenseNet.Packaging.Tests\SenseNet.Packaging.Tests.csproj">
+      <Project>{6B711835-9172-4F07-9FC3-BA79C7DFA916}</Project>
+      <Name>SenseNet.Packaging.Tests</Name>
     </ProjectReference>
     <ProjectReference Include="..\SenseNet.Tests\SenseNet.Tests.csproj">
       <Project>{A0909E8F-E039-4080-A259-676CFD38CCD1}</Project>

--- a/src/Tests/SenseNet.ContentRepository.Tests/UnknownContentHandlerTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/UnknownContentHandlerTests.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SenseNet.ContentRepository.Schema;
+using SenseNet.ContentRepository.Storage;
+using SenseNet.ContentRepository.Storage.Data;
+using SenseNet.ContentRepository.Storage.Schema;
+using SenseNet.Packaging.Tests.Implementations;
+using SenseNet.Storage;
+using SenseNet.Tests;
+using SenseNet.Tests.Implementations;
+
+namespace SenseNet.ContentRepository.Tests
+{
+    [TestClass]
+    public class UnknownContentHandlerTests : TestBase
+    {
+        protected override RepositoryBuilder CreateRepositoryBuilderForTestInstance()
+        {
+            //UNDONE: temp reference to the SenseNet.Packaging.Tests 
+            // because of the packaging storage provider below.
+            var builder = base.CreateRepositoryBuilderForTestInstance();
+            builder.UsePackagingDataProviderExtension(new TestPackageStorageProvider());
+
+            return builder;
+        }
+
+        [TestMethod]
+        public void UnknownHandler_CreateContent()
+        {
+            Test(() =>
+            {
+                // allow the File type in the root because we'll need it later
+                var parent = Node.Load<GenericContent>("/Root");
+                parent.AllowChildType("File", save: true);
+
+                // create a system folder
+                var sysFolderName = Guid.NewGuid().ToString();
+                var sysFolder = Content.CreateNew("SystemFolder", parent, sysFolderName);
+                sysFolder.Save();
+                var originalFieldNames = string.Join(",", sysFolder.Fields.Keys);
+
+                // set the handler of the Folder type to an unknown value
+                SetContentHandler("Folder", "unknownhandler");
+
+                ResetAndFailToCreateContent();
+
+                parent = Node.Load<GenericContent>("/Root");
+                var folderType = ContentTypeManager.Instance.GetContentTypeByName("Folder");
+
+                // check if all related types are marked as unknown
+                foreach (var contentType in ContentTypeManager.Instance.ContentTypes.Values)
+                {
+                    Assert.AreEqual(string.Equals(contentType.Path, folderType.Path) ||
+                                    contentType.Path.StartsWith(folderType.Path + RepositoryPath.PathSeparator),
+                        contentType.IsInvalid);
+                }
+
+                // load a previously created system folder and iterate through its fields
+                sysFolder = Content.Load(sysFolder.Id);
+                var afterFieldNames = string.Join(",", sysFolder.Fields.Keys);
+                
+                Assert.AreEqual(originalFieldNames, afterFieldNames);
+
+                foreach (var field in sysFolder.Fields)
+                {
+                    // check if field values can be loaded
+                    var val = field.Value;
+                }
+
+                // This should be allowed because the handler is known
+                // and it does not inherit from Folder.
+                var file = Content.CreateNew("File", parent, Guid.NewGuid().ToString());
+                file.Save();
+            });
+        }
+
+        [TestMethod]
+        public void UnknownHandler_GetNameByType()
+        {
+            Test(() =>
+            {
+                SetContentHandlerAndResetManagers(() =>
+                {
+                    // This should not throw an exception. The returned type is irrelevant: 
+                    // it will be one of the descendants of the Folder content type.
+                    var typeName = ContentTypeManager.GetContentTypeNameByType(typeof(Folder));
+                });
+            });
+        }
+        [TestMethod]
+        [ExpectedException(typeof(RegistrationException))]
+        public void UnknownHandler_CreateUnknownHandler()
+        {
+            Test(() =>
+            {
+                SetContentHandlerAndResetManagers(() =>
+                {
+                    var _ = new UnknownContentHandler(Node.Load<GenericContent>("/Root"));
+                });
+            });
+        }
+        [TestMethod]
+        public void UnknownHandler_GetContentTypeByHandler()
+        {
+            Test(() =>
+            {
+                SetContentHandlerAndResetManagers(() =>
+                {
+                    var parent = Node.Load<GenericContent>("/Root");
+                    var content = Content.CreateNew("Folder", parent, Guid.NewGuid().ToString());
+
+                    Assert.IsTrue(content.ContentHandler is UnknownContentHandler);
+
+                    var contentType = ContentTypeManager.Instance.GetContentTypeByHandler(content.ContentHandler);
+
+                    // we have found the type despite the missing handler
+                    Assert.AreEqual("Folder", contentType.Name);
+                });
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RegistrationException))]
+        public void UnknownHandler_InstallUnknownContentType()
+        {
+            var unknownHandlerCTD = @"<?xml version='1.0' encoding='utf-8'?>
+<ContentType name='UnknownContent' parentType='GenericContent' handler='unknown' xmlns='http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition'>
+</ContentType>
+";
+
+            Test(() =>
+            {
+                ContentTypeInstaller.InstallContentType(unknownHandlerCTD);
+            });
+        }
+        [TestMethod]
+        [ExpectedException(typeof(RegistrationException))]
+        public void UnknownHandler_InstallContentType_UnknownParent()
+        {
+            var testSystemHandlerCTD = @"<?xml version='1.0' encoding='utf-8'?>
+<ContentType name='TestSystemFolder' parentType='SystemFolder' handler='SenseNet.ContentRepository.Tests.TestSystemFolder' xmlns='http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition'>
+</ContentType>
+";
+
+            Test(() =>
+            {
+                // set the handler of the Folder type to an unknown value
+                SetContentHandler("Folder", "unknownhandler");
+
+                NodeTypeManager.Restart();
+                ContentTypeManager.Reset();
+                DistributedApplication.Cache.Reset();
+
+                // this should throw an exception: installing a content type with an unknown parent
+                ContentTypeInstaller.InstallContentType(testSystemHandlerCTD);
+            });
+        }
+
+        [TestMethod]
+        public void UnknownHandler_CreateContent_UnknownFieldType()
+        {
+            Test(() =>
+            {
+                // add a field with an unknown short name
+                AddField("Folder", "TestField", "unknown");
+
+                ResetAndFailToCreateContent();
+            });
+        }
+        [TestMethod]
+        public void UnknownHandler_CreateContent_UnknownFieldHandler()
+        {
+            Test(() =>
+            {
+                // add a field with an unknown handler
+                AddField("Folder", "TestField", null, "unknown");
+
+                ResetAndFailToCreateContent();
+            });
+        }
+
+        [TestMethod]
+        public void UnknownHandler_CreateContent_FieldTable()
+        {
+            // This test is necessary because the OData layer calls the field name getter method.
+            Test(() =>
+            {
+                var parent = Node.Load<GenericContent>("/Root");
+                var content = Content.CreateNew("Folder", parent, Guid.NewGuid().ToString());
+                var fieldNamesBefore = string.Join(",", content.GetFieldNamesInParentTable().OrderBy(fn => fn));
+
+                // set the handler of the Folder type to an unknown value
+                SetContentHandler("Folder", "unknownhandler");
+
+                DistributedApplication.Cache.Reset();
+                NodeTypeManager.Restart();
+                ContentTypeManager.Reload();
+
+                parent = Node.Load<GenericContent>("/Root");
+                content = Content.CreateNew("Folder", parent, Guid.NewGuid().ToString());
+                var fieldNamesAfter = string.Join(",", content.GetFieldNamesInParentTable().OrderBy(fn => fn));
+
+                Assert.AreEqual(fieldNamesBefore, fieldNamesAfter);
+            });
+        }
+
+        private static void ResetAndFailToCreateContent()
+        {
+            DistributedApplication.Cache.Reset();
+            NodeTypeManager.Restart();
+            ContentTypeManager.Reload();
+
+            var parent = Node.Load<GenericContent>("/Root");
+
+            // try to create a content with an unknown field
+            ExpectException(() =>
+            {
+                var content = Content.CreateNew("Folder", parent, Guid.NewGuid().ToString());
+                content.Save();
+            }, typeof(SnNotSupportedException));
+
+            // try to create a content with a known handler that has an unknown parent
+            ExpectException(() =>
+            {
+                var content = Content.CreateNew("SystemFolder", parent, Guid.NewGuid().ToString());
+                content.Save();
+            }, typeof(SnNotSupportedException));
+        }
+        private static void ExpectException(Action action, Type exceptionType)
+        {
+            var thrown = false;
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                if (exceptionType.IsInstanceOfType(ex))
+                    thrown = true;
+            }
+
+            Assert.IsTrue(thrown, $"{exceptionType.Name} was not thrown.");
+        }
+
+        private static void SetContentHandlerAndResetManagers(Action action)
+        {
+            // set the handler of the Folder type to an unknown value
+            SetContentHandler("Folder", "unknownhandler");
+
+            DistributedApplication.Cache.Reset();
+            NodeTypeManager.Restart();
+            ContentTypeManager.Reload();
+
+            action();
+        }
+
+        private static void SetContentHandler(string contentTypeName, string handler)
+        {
+            var testingDataProvider = DataProvider.GetExtension<ITestingDataProviderExtension>();
+            if (testingDataProvider == null)
+                Assert.Inconclusive($"{nameof(ITestingDataProviderExtension)} implementation is not available.");
+
+            testingDataProvider.SetContentHandler(contentTypeName, handler);
+        }
+        private static void AddField(string contentTypeName, string fieldName, string fieldType = null, string fieldHandler = null)
+        {
+            var testingDataProvider = DataProvider.GetExtension<ITestingDataProviderExtension>();
+            if (testingDataProvider == null)
+                Assert.Inconclusive($"{nameof(ITestingDataProviderExtension)} implementation is not available.");
+
+            testingDataProvider.AddField(contentTypeName, fieldName, fieldType, fieldHandler);
+        }
+    }
+
+    [ContentHandler]
+    public class TestSystemFolder : SystemFolder
+    {
+        public TestSystemFolder(Node parent) : this(parent, null) {  }
+        public TestSystemFolder(Node parent, string nodeTypeName) : base(parent, nodeTypeName) { }
+        protected TestSystemFolder(NodeToken nt) : base(nt) { }
+    }
+}

--- a/src/Tests/SenseNet.ContentRepository.Tests/UnknownContentHandlerTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/UnknownContentHandlerTests.cs
@@ -41,7 +41,7 @@ namespace SenseNet.ContentRepository.Tests
                 var originalFieldNames = string.Join(",", sysFolder.Fields.Keys);
 
                 // set the handler of the Folder type to an unknown value
-                SetContentHandler("Folder", "unknownhandler");
+                SetContentHandler("Folder", "UnknownCreateContent");
 
                 ResetAndFailToCreateContent();
 
@@ -80,7 +80,7 @@ namespace SenseNet.ContentRepository.Tests
         {
             Test(() =>
             {
-                SetContentHandlerAndResetManagers(() =>
+                SetContentHandlerAndResetManagers("UnknownGetNameByType", () =>
                 {
                     // This should not throw an exception. The returned type is irrelevant: 
                     // it will be one of the descendants of the Folder content type.
@@ -94,7 +94,7 @@ namespace SenseNet.ContentRepository.Tests
         {
             Test(() =>
             {
-                SetContentHandlerAndResetManagers(() =>
+                SetContentHandlerAndResetManagers("UnknownCreateUnknownHandler", () =>
                 {
                     var _ = new UnknownContentHandler(Node.Load<GenericContent>("/Root"));
                 });
@@ -105,7 +105,7 @@ namespace SenseNet.ContentRepository.Tests
         {
             Test(() =>
             {
-                SetContentHandlerAndResetManagers(() =>
+                SetContentHandlerAndResetManagers("UnknownGetContentTypeByHandler", () =>
                 {
                     var parent = Node.Load<GenericContent>("/Root");
                     var content = Content.CreateNew("Folder", parent, Guid.NewGuid().ToString());
@@ -121,7 +121,7 @@ namespace SenseNet.ContentRepository.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(RegistrationException))]
+        [ExpectedException(typeof(ContentRegistrationException))]
         public void UnknownHandler_InstallUnknownContentType()
         {
             var unknownHandlerCTD = @"<?xml version='1.0' encoding='utf-8'?>
@@ -146,7 +146,7 @@ namespace SenseNet.ContentRepository.Tests
             Test(() =>
             {
                 // set the handler of the Folder type to an unknown value
-                SetContentHandler("Folder", "unknownhandler");
+                SetContentHandler("Folder", "UnknownParent");
 
                 NodeTypeManager.Restart();
                 ContentTypeManager.Reset();
@@ -191,7 +191,7 @@ namespace SenseNet.ContentRepository.Tests
                 var fieldNamesBefore = string.Join(",", content.GetFieldNamesInParentTable().OrderBy(fn => fn));
 
                 // set the handler of the Folder type to an unknown value
-                SetContentHandler("Folder", "unknownhandler");
+                SetContentHandler("Folder", "UnknownFieldTable");
 
                 DistributedApplication.Cache.Reset();
                 NodeTypeManager.Restart();
@@ -243,10 +243,10 @@ namespace SenseNet.ContentRepository.Tests
             Assert.IsTrue(thrown, $"{exceptionType.Name} was not thrown.");
         }
 
-        private static void SetContentHandlerAndResetManagers(Action action)
+        private static void SetContentHandlerAndResetManagers(string handlerName, Action action)
         {
             // set the handler of the Folder type to an unknown value
-            SetContentHandler("Folder", "unknownhandler");
+            SetContentHandler("Folder", handlerName);
 
             DistributedApplication.Cache.Reset();
             NodeTypeManager.Restart();

--- a/src/Tests/SenseNet.Packaging.Tests/PackagingEzReleaseTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PackagingEzReleaseTests.cs
@@ -153,6 +153,11 @@ namespace SenseNet.Packaging.Tests
         {
             public string ComponentId { get; }
             public Version SupportedVersion { get; }
+
+            public TestComponent()
+            {
+                // Default contructor is needed to support automatic instantiation.
+            }
             public TestComponent(string componentId, string supportedVersion, bool allowed = true)
             {
                 ComponentId = componentId;
@@ -165,6 +170,8 @@ namespace SenseNet.Packaging.Tests
             {
                 return _allowed;
             }
+
+            public SnPatch[] Patches { get; }
         }
     }
 }

--- a/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
@@ -34,8 +34,7 @@ namespace SenseNet.Packaging.Tests
             var loggerAcc = new PrivateType(typeof(Logger));
             loggerAcc.SetStaticField("_loggers", loggers);
 
-            var builder = CreateRepositoryBuilderForTest();
-            builder.UsePackagingDataProviderExtension(new TestPackageStorageProvider());
+            var unused = CreateRepositoryBuilderForTestInstance();
 
             RepositoryVersionInfo.Reset();
         }
@@ -43,6 +42,14 @@ namespace SenseNet.Packaging.Tests
         public void AfterTest()
         {
             // do nothing
+        }
+
+        protected override RepositoryBuilder CreateRepositoryBuilderForTestInstance()
+        {
+            var builder = base.CreateRepositoryBuilderForTestInstance();
+            builder.UsePackagingDataProviderExtension(new TestPackageStorageProvider());
+
+            return builder;
         }
 
         /*================================================= tools */

--- a/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PackagingTestBase.cs
@@ -98,7 +98,7 @@ namespace SenseNet.Packaging.Tests
             PackagingResult result;
             do
             {
-                result = ExecutePhase(manifestXml, ++phase, console ?? new StringWriter());
+                result = ExecutePhase(manifestXml, ++phase, console);
                 errors += result.Errors;
             } while (result.NeedRestart);
             result.Errors = errors;
@@ -107,7 +107,7 @@ namespace SenseNet.Packaging.Tests
         protected PackagingResult ExecutePhase(XmlDocument manifestXml, int phase, TextWriter console = null)
         {
             var manifest = Manifest.Parse(manifestXml, phase, true, new PackageParameter[0]);
-            var executionContext = ExecutionContext.CreateForTest("packagePath", "targetPath", new string[0], "sandboxPath", manifest, phase, manifest.CountOfPhases, null, console ?? new StringWriter());
+            var executionContext = ExecutionContext.CreateForTest("packagePath", "targetPath", new string[0], "sandboxPath", manifest, phase, manifest.CountOfPhases, null, console);
             var result = PackageManager.ExecuteCurrentPhase(manifest, executionContext);
             RepositoryVersionInfo.Reset();
             return result;

--- a/src/Tests/SenseNet.Packaging.Tests/RepositoryStartTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/RepositoryStartTests.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Storage;
+using SenseNet.ContentRepository.Storage.Data;
+using SenseNet.Packaging.Tests.Implementations;
+
+namespace SenseNet.Packaging.Tests
+{
+    #region Test components
+    internal class TestComponentOnePatch : ISnComponent
+    {
+        public string ComponentId => nameof(TestComponentOnePatch);
+        public Version SupportedVersion { get; } = new Version(1, 1);
+        public bool IsComponentAllowed(Version componentVersion)
+        {
+            return true;
+        }
+        public SnPatch[] Patches { get; } = 
+        {
+            new SnPatch
+            {
+                Version = new Version(1, 1),
+                MaxVersion = new Version(1, 0),
+                MinVersion = new Version(1, 0),
+                Contents = @"<?xml version='1.0' encoding='utf-8'?>
+                        <Package type='Patch'>
+                            <Id>" + nameof(TestComponentOnePatch) + @"</Id>
+                            <ReleaseDate>2018-01-01</ReleaseDate>
+                            <Version>1.1</Version>
+                            <Dependencies>
+                                <Dependency id='" + nameof(TestComponentOnePatch) + @"' minVersion='1.0' maxVersion='1.0' />
+                            </Dependencies>
+                        </Package>"
+            }
+        };
+    }
+    internal class TestComponentNoPatch : ISnComponent
+    {
+        public string ComponentId => nameof(TestComponentNoPatch);
+        public Version SupportedVersion { get; } = new Version(1, 1);
+        public bool IsComponentAllowed(Version componentVersion)
+        {
+            return true;
+        }
+        public SnPatch[] Patches { get; } = new SnPatch[0];
+    }
+    internal class TestComponentMultiPatch : ISnComponent
+    {
+        public string ComponentId => nameof(TestComponentMultiPatch);
+        public Version SupportedVersion { get; } = new Version(1, 2);
+        public bool IsComponentAllowed(Version componentVersion)
+        {
+            return true;
+        }
+        public SnPatch[] Patches { get; } =
+        {
+            new SnPatch
+            {
+                Version = new Version(1, 1),
+                MaxVersion = new Version(1, 0),
+                MinVersion = new Version(1, 0),
+                Contents = @"<?xml version='1.0' encoding='utf-8'?>
+                        <Package type='Patch'>
+                            <Id>" + nameof(TestComponentMultiPatch) + @"</Id>
+                            <ReleaseDate>2018-01-01</ReleaseDate>
+                            <Version>1.1</Version>
+                            <Dependencies>
+                                <Dependency id='" + nameof(TestComponentMultiPatch) + @"' minVersion='1.0' maxVersion='1.0' />
+                            </Dependencies>
+                        </Package>"
+            },
+            new SnPatch
+            {
+                Version = new Version(1, 2),
+                MaxVersion = new Version(1, 1),
+                MinVersion = new Version(1, 1),
+                Contents = @"<?xml version='1.0' encoding='utf-8'?>
+                        <Package type='Patch'>
+                            <Id>" + nameof(TestComponentMultiPatch) + @"</Id>
+                            <ReleaseDate>2018-01-01</ReleaseDate>
+                            <Version>1.2</Version>
+                            <Dependencies>
+                                <Dependency id='" + nameof(TestComponentMultiPatch) + @"' minVersion='1.1' maxVersion='1.1' />
+                            </Dependencies>
+                        </Package>"
+            }
+        };
+    }
+    internal class TestComponentMultiPatchExclusive : ISnComponent
+    {
+        public string ComponentId => nameof(TestComponentMultiPatchExclusive);
+        public Version SupportedVersion { get; } = new Version(2, 5);
+        public bool IsComponentAllowed(Version componentVersion)
+        {
+            return true;
+        }
+        public SnPatch[] Patches { get; } =
+        {
+            new SnPatch
+            {
+                Version = new Version(3, 0),
+                MaxVersion = new Version(2, 0),
+                MaxVersionIsExclusive = true,
+                MinVersion = new Version(1, 0),
+                Contents = "<?xml>skipped"
+            },
+            new SnPatch
+            {
+                Version = new Version(3, 0),
+                MaxVersion = new Version(3, 0),
+                MaxVersionIsExclusive = true,
+                MinVersion = new Version(2, 0),
+                MinVersionIsExclusive = true,
+                Contents = "<?xml>skipped"
+            }
+        };
+    }
+    internal class TestComponentMultiPatchIncorrectFormat : ISnComponent
+    {
+        public string ComponentId => nameof(TestComponentMultiPatchIncorrectFormat);
+        public Version SupportedVersion { get; } = new Version(1, 2);
+        public bool IsComponentAllowed(Version componentVersion)
+        {
+            return true;
+        }
+        public SnPatch[] Patches { get; } =
+        {
+            new SnPatch
+            {
+                Version = new Version(1, 1),
+                MaxVersion = new Version(1, 0),
+                MinVersion = new Version(1, 0),
+                Contents = @"<?xml version='1.0' encoding='utf-8'?>
+                        <Package type='Patch'>
+                            <Id>" + nameof(TestComponentMultiPatchIncorrectFormat) + @"</Id>
+                            <ReleaseDate>2018-01-01</ReleaseDate>
+                            <Version>1.1</Version>
+                            <Dependencies>
+                                <Dependency id='" + nameof(TestComponentMultiPatchIncorrectFormat) + @"' minVersion='1.0' maxVersion='1.0' />
+                            </Dependencies>
+                        </Package>"
+            },
+            // this package contains an invalid manifest xml
+            new SnPatch
+            {
+                Version = new Version(1, 2),
+                MaxVersion = new Version(1, 1),
+                MinVersion = new Version(1, 1),
+                Contents = @"<?xml version='1.0' encoding='utf-8'?>
+                        <Package type='Patch'>
+                            <Id>" + nameof(TestComponentMultiPatchIncorrectFormat) + @"</Id>
+                            <ReleaseDate>                            
+                        </Package>"
+            }
+        };
+    }
+    #endregion
+
+    [TestClass]
+    public class RepositoryStartTests : PackagingTestBase
+    {
+        [TestInitialize]
+        public void InitializePackagingTest()
+        {
+            DataProvider.Instance.SetExtension(typeof(IPackagingDataProviderExtension), new TestPackageStorageProvider());
+
+            // make sure that every test starts with a clean slate (no existing installed components)
+            PackageManager.Storage.DeleteAllPackages();
+        }
+
+        [TestMethod]
+        public void Packaging_NoPatchNeeded()
+        {
+            PatchAndCheck(nameof(TestComponentOnePatch),
+                new[] {new Version(1, 0), new Version(1, 1)},
+                null,
+                null,
+                new Version(1, 1));
+        }
+        [TestMethod]
+        public void Packaging_OnePatch()
+        {
+            PatchAndCheck(nameof(TestComponentOnePatch),
+                new[] {new Version(1, 0)},
+                new[] {new Version(1, 1)},
+                null,
+                new Version(1, 1));
+        }
+        [TestMethod]
+        public void Packaging_MultiPatch()
+        {
+            PatchAndCheck(nameof(TestComponentMultiPatch),
+                new[] {new Version(1, 0)},
+                new[] {new Version(1, 1), new Version(1, 2)},
+                null,
+                new Version(1, 2));
+        }
+        [TestMethod]
+        public void Packaging_MultiPatch_SkipPatch()
+        {
+            PatchAndCheck(nameof(TestComponentMultiPatch),
+                new[] {new Version(1, 1)},
+                new[] {new Version(1, 2)},
+                null,
+                new Version(1, 2));
+        }
+        [TestMethod]
+        public void Packaging_MultiPatch_Exclusive()
+        {
+            PatchAndCheck(nameof(TestComponentMultiPatchExclusive),
+                new[] { new Version(2, 0) },
+                null,
+                null,
+                new Version(2, 0));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidPackageException))]
+        public void Packaging_MultiPatch_IncorrectFormat()
+        {
+            PatchAndCheck(nameof(TestComponentMultiPatchIncorrectFormat),
+                new[] { new Version(1, 0) },
+                null, null, null);
+        }
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Packaging_MissingPatch()
+        {
+            // The Supported version of this component is v1.1, but there is no patch
+            // in the assembly, so we expect an exception here.
+            PatchAndCheck(nameof(TestComponentNoPatch),
+                new[] {new Version(1, 0)},
+                null,
+                null,
+                null);
+        }
+
+        [TestMethod]
+        public void Packaging_Comparer()
+        {
+            Assert.AreEqual("C1,C2,C3",
+                string.Join(",",
+                    new[] { "C3", "C2", "C1" }.OrderBy(c => c,
+                        new RepositoryVersionInfo.SnComponentComparer(new[] { "C1", "C2", "C3" })).ToArray()));
+
+            Assert.AreEqual("C1,C3,C4,C5",
+                string.Join(",",
+                    new[] { "C4", "C3", "C5", "C1" }.OrderBy(c => c,
+                        new RepositoryVersionInfo.SnComponentComparer(new[] { "C1", "C2", "C3" })).ToArray()));
+        }
+
+        private static void PatchAndCheck(string componentId, 
+            Version[] packageVersions,
+            Version[] successfulPatchVersions,
+            Version[] failedPatchVersions,
+            Version expectedVersion)
+        {
+            Version initialVersion = null;
+
+            // install mock packages
+            if (packageVersions?.Any() ?? false)
+            {
+                // the first should be an install package, Patch packages will follow
+                var install = true;
+
+                foreach (var packageVersion in packageVersions)
+                {
+                    PackageManager.Storage.SavePackage(new Package
+                    {
+                        ComponentId = componentId,
+                        ComponentVersion = packageVersion,
+                        ExecutionResult = ExecutionResult.Successful,
+                        PackageType = install ? PackageType.Install : PackageType.Patch
+                    });
+
+                    install = false;
+                }
+
+                RepositoryVersionInfo.Reset();
+
+                initialVersion = packageVersions.Last();
+            }
+
+            var installedComponent = RepositoryVersionInfo.Instance.Components.Single(c => c.ComponentId == componentId);
+            if (installedComponent != null)
+                Assert.AreEqual(initialVersion, installedComponent.Version);
+
+            var assemblyComponent = RepositoryVersionInfo.GetAssemblyComponents()
+                .Single(c => c.ComponentId == componentId);
+
+            // ACTION
+            var results = PackageManager.ExecuteAssemblyPatch(assemblyComponent);
+
+            // reload version info
+            installedComponent = RepositoryVersionInfo.Instance.Components.Single(c => c.ComponentId == componentId);
+            
+            if (successfulPatchVersions?.Any() ?? false)
+            {
+                // the component was successfully upgraded
+                foreach (var patchVersion in successfulPatchVersions)
+                    Assert.IsTrue(results[patchVersion].Successful);
+            }
+            if (failedPatchVersions?.Any() ?? false)
+            {
+                // there should be failed patch results
+                foreach (var patchVersion in failedPatchVersions)
+                    Assert.IsFalse(results[patchVersion].Successful);
+            }
+
+            if (!(successfulPatchVersions?.Any() ?? false) && !(failedPatchVersions?.Any() ?? false))
+            {
+                // no patch is expected
+                Assert.IsFalse(results?.Keys.Any() ?? false);
+            }
+
+            if (installedComponent != null)
+                Assert.AreEqual(expectedVersion, installedComponent.Version);
+        }
+    }
+}

--- a/src/Tests/SenseNet.Packaging.Tests/RepositoryStartTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/RepositoryStartTests.cs
@@ -597,7 +597,7 @@ namespace SenseNet.Packaging.Tests
                 .Single(c => c.ComponentId == componentId);
 
             // ACTION
-            var results = PackageManager.ExecuteAssemblyPatch(assemblyComponent);
+            var results = PackageManager.ExecuteAssemblyPatches(assemblyComponent);
 
             // reload version info
             installedComponent = RepositoryVersionInfo.Instance.Components.Single(c => c.ComponentId == componentId);

--- a/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
+++ b/src/Tests/SenseNet.Packaging.Tests/SenseNet.Packaging.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="PackagingTestBase.cs" />
     <Compile Include="PackagingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepositoryStartTests.cs" />
     <Compile Include="StepTests\DeleteContentTypeTests.cs" />
     <Compile Include="StepTests\EditAllowedChildTypesTests.cs" />
     <Compile Include="StepTests\EditConfigurationTests.cs" />

--- a/src/Tests/SenseNet.Packaging.Tests/StepTests/DeleteContentTypeTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/StepTests/DeleteContentTypeTests.cs
@@ -19,18 +19,8 @@ using SenseNet.Tests;
 namespace SenseNet.Packaging.Tests.StepTests
 {
     [TestClass]
-    public class DeleteContentTypeTests : TestBase
+    public class DeleteContentTypeTests : PackagingTestBase
     {
-        private static StringBuilder _log;
-        [TestInitialize]
-        public void PrepareTest()
-        {
-            // preparing logger
-            _log = new StringBuilder();
-            var loggers = new[] { new PackagingTestLogger(_log) };
-            var loggerAcc = new PrivateType(typeof(Logger));
-            loggerAcc.SetStaticField("_loggers", loggers);
-        }
         [TestCleanup]
         public void AfterTest()
         {

--- a/src/Tests/SenseNet.Tests/Implementations/ITestingDataProvider.cs
+++ b/src/Tests/SenseNet.Tests/Implementations/ITestingDataProvider.cs
@@ -17,5 +17,8 @@ namespace SenseNet.Tests.Implementations
         void CheckScript(string commandText);
         IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForOneNodeIntegrityCheck(string path, Int32[] excludedNodeTypeIds);
         IEnumerable<IndexIntegrityCheckerItem> GetTimestampDataForRecursiveIntegrityCheck(string path, Int32[] excludedNodeTypeIds);
+
+        void SetContentHandler(string contentTypeName, string handler);
+        void AddField(string contentTypeName, string fieldName, string fieldType = null, string fieldHandler = null);
     }
 }

--- a/src/Tests/SenseNet.Tests/Implementations/InMemoryDataProvider.cs
+++ b/src/Tests/SenseNet.Tests/Implementations/InMemoryDataProvider.cs
@@ -1406,8 +1406,6 @@ namespace SenseNet.Tests.Implementations
         }
 
         private static Database _prototype;
-        public static Database Prototype => _prototype;
-
         private readonly Database _db;
         public Database DB => _db;
 

--- a/src/Tests/SenseNet.Tests/Implementations/InMemoryDataProvider.cs
+++ b/src/Tests/SenseNet.Tests/Implementations/InMemoryDataProvider.cs
@@ -1406,6 +1406,8 @@ namespace SenseNet.Tests.Implementations
         }
 
         private static Database _prototype;
+        public static Database Prototype => _prototype;
+
         private readonly Database _db;
         public Database DB => _db;
 

--- a/src/Tests/SenseNet.Tests/Implementations/InMemoryTestingDataProvider.cs
+++ b/src/Tests/SenseNet.Tests/Implementations/InMemoryTestingDataProvider.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
+using SenseNet.ContentRepository.Schema;
 using SenseNet.ContentRepository.Storage.Data;
+using SenseNet.ContentRepository.Storage.Schema;
 using SenseNet.Diagnostics;
 
 namespace SenseNet.Tests.Implementations
@@ -54,6 +58,93 @@ namespace SenseNet.Tests.Implementations
         public virtual string TestMethodThatIsNotInterfaceMember(string input)
         {
             return input + input;
+        }
+
+        public void SetContentHandler(string contentTypeName, string handler)
+        {
+            var fileRecord = DB.Files.First(ff =>
+                ff.Extension == ".ContentType" && ff.FileNameWithoutExtension == contentTypeName);
+
+            // change handler in the blob
+            EditFileStream(fileRecord, xDoc =>
+            {
+                xDoc.DocumentElement.Attributes["handler"].Value = handler;
+            });
+
+            // change handler in the preloaded xml schema
+            var schema = DB.Schema;
+            var nsmgr = new XmlNamespaceManager(schema.NameTable);
+            nsmgr.AddNamespace("x", SchemaRoot.RepositoryStorageSchemaXmlNamespace);
+
+            var classNameAttr = schema.SelectSingleNode($"/x:StorageSchema/x:NodeTypeHierarchy//x:NodeType[@name='{contentTypeName}']",
+                nsmgr)?.Attributes?["className"];
+
+            if (classNameAttr != null)
+                classNameAttr.Value = handler;
+            else
+                throw new InvalidOperationException($"NodeType not found: {contentTypeName}");
+        }
+        public void AddField(string contentTypeName, string fieldName, string fieldType = null, string fieldHandler = null)
+        {
+            var fileRecord = DB.Files.First(ff =>
+                ff.Extension == ".ContentType" && ff.FileNameWithoutExtension == contentTypeName);
+
+            // change field in the blob
+            EditFileStream(fileRecord, xDoc =>
+            {
+                var fieldNode = xDoc.CreateElement("Field", ContentType.ContentDefinitionXmlNamespace);
+                fieldNode.SetAttribute("name", fieldName);
+
+                if (!string.IsNullOrEmpty(fieldType))
+                    fieldNode.SetAttribute("type", fieldType);
+                if (!string.IsNullOrEmpty(fieldHandler))
+                    fieldNode.SetAttribute("handler", fieldHandler);
+
+                var fields = xDoc.DocumentElement["Fields"];
+                fields.AppendChild(fieldNode);
+            });
+
+            // change field in the preloaded xml schema
+            var schema = DB.Schema;
+            var nsmgr = new XmlNamespaceManager(schema.NameTable);
+            nsmgr.AddNamespace("x", SchemaRoot.RepositoryStorageSchemaXmlNamespace);
+
+            var propsNode = schema.SelectSingleNode("/x:StorageSchema/x:UsedPropertyTypes", nsmgr);
+            var propTypeId = propsNode.ChildNodes.Cast<XmlNode>().Select(pn => int.Parse(pn.Attributes["itemID"].Value))
+                                 .Max() + 1;
+
+            var propNode = schema.CreateElement("PropertyType", SchemaRoot.RepositoryStorageSchemaXmlNamespace);
+            propNode.SetAttribute("itemID", propTypeId.ToString());
+            propNode.SetAttribute("name", fieldName);
+            propNode.SetAttribute("dataType", "String");
+            propNode.SetAttribute("mapping", "100");
+
+            propsNode.AppendChild(propNode);
+
+            var typeNode = schema
+                .SelectSingleNode($"/x:StorageSchema/x:NodeTypeHierarchy//x:NodeType[@name='{contentTypeName}']",
+                    nsmgr);
+
+            propNode = schema.CreateElement("PropertyType", SchemaRoot.RepositoryStorageSchemaXmlNamespace);
+            propNode.SetAttribute("name", fieldName);
+
+            typeNode.AppendChild(propNode);
+        }
+
+        private static void EditFileStream(InMemoryDataProvider.FileRecord fileRecord, Action<XmlDocument> action)
+        {
+            using (var xmlReaderStream = new MemoryStream(fileRecord.Stream))
+            {
+                var gcXmlDoc = new XmlDocument();
+                gcXmlDoc.Load(xmlReaderStream);
+
+                action(gcXmlDoc);
+
+                var ctdString = gcXmlDoc.OuterXml;
+
+                fileRecord.Stream = Encoding.UTF8.GetBytes(ctdString);
+                fileRecord.Size = fileRecord.Stream.Length;
+            }
         }
     }
 }

--- a/src/Tests/SenseNet.Tests/TestBase.cs
+++ b/src/Tests/SenseNet.Tests/TestBase.cs
@@ -178,6 +178,7 @@ namespace SenseNet.Tests
             return new RepositoryBuilder()
                 .UseAccessProvider(new DesktopAccessProvider())
                 .UseDataProvider(dataProvider)
+                .UseTestingDataProviderExtension(new InMemoryTestingDataProvider())
                 .UseSharedLockDataProviderExtension(new InMemorySharedLockDataProvider())
                 .UseBlobMetaDataProvider(new InMemoryBlobStorageMetaDataProvider(dataProvider))
                 .UseBlobProviderSelector(new InMemoryBlobProviderSelector())

--- a/src/Tests/SenseNet.Tests/TestBase.cs
+++ b/src/Tests/SenseNet.Tests/TestBase.cs
@@ -105,7 +105,7 @@ namespace SenseNet.Tests
             var portalContextAcc = new PrivateType(typeof(PortalContext));
             portalContextAcc.SetStaticField("_sites", new Dictionary<string, Site>());
 
-            var builder = CreateRepositoryBuilderForTest();
+            var builder = CreateRepositoryBuilderForTestInstance();
 
             initialize?.Invoke(builder);
 
@@ -151,7 +151,7 @@ namespace SenseNet.Tests
             DistributedApplication.Cache.Reset();
             ContentTypeManager.Reset();
 
-            var builder = CreateRepositoryBuilderForTest();
+            var builder = CreateRepositoryBuilderForTestInstance();
 
             initialize?.Invoke(builder);
 
@@ -189,6 +189,11 @@ namespace SenseNet.Tests
                 .DisableNodeObservers()
                 .EnableNodeObservers(typeof(SettingsCache))
                 .UseTraceCategories("Test", "Event", "Custom") as RepositoryBuilder;
+        }
+
+        protected virtual RepositoryBuilder CreateRepositoryBuilderForTestInstance()
+        {
+            return CreateRepositoryBuilderForTest();
         }
 
         protected static ISecurityDataProvider GetSecurityDataProvider(InMemoryDataProvider repo)

--- a/src/Tests/SenseNet.Tests/TestBase.cs
+++ b/src/Tests/SenseNet.Tests/TestBase.cs
@@ -27,7 +27,7 @@ namespace SenseNet.Tests
 
         private static volatile bool _prototypesCreated;
         private static readonly object PrototypeSync = new object();
-        private void EnsurePrototypes()
+        protected void EnsurePrototypes()
         {
             if (!_prototypesCreated)
             {

--- a/src/Tests/SenseNet.Tests/TestBase.cs
+++ b/src/Tests/SenseNet.Tests/TestBase.cs
@@ -27,7 +27,7 @@ namespace SenseNet.Tests
 
         private static volatile bool _prototypesCreated;
         private static readonly object PrototypeSync = new object();
-        protected void EnsurePrototypes()
+        private void EnsurePrototypes()
         {
             if (!_prototypesCreated)
             {
@@ -102,6 +102,8 @@ namespace SenseNet.Tests
         {
             DistributedApplication.Cache.Reset();
             ContentTypeManager.Reset();
+            Providers.Instance.NodeTypeManeger = null;
+
             var portalContextAcc = new PrivateType(typeof(PortalContext));
             portalContextAcc.SetStaticField("_sites", new Dictionary<string, Site>());
 

--- a/src/Tests/SenseNet.Tests/Tools.cs
+++ b/src/Tests/SenseNet.Tests/Tools.cs
@@ -4,6 +4,7 @@ using SenseNet.ContentRepository.Storage;
 using SenseNet.Search;
 using SenseNet.ContentRepository.Storage.Data;
 using SenseNet.Configuration;
+using SenseNet.Diagnostics;
 
 namespace SenseNet.Tests
 {
@@ -64,6 +65,27 @@ namespace SenseNet.Tests
             public void Dispose()
             {
                 Providers.Instance.DataProvider = _providerInstanceBackup;
+            }
+        }
+
+        public class LoggerSwindler<T> : IDisposable where T : class, IEventLogger
+        {
+            private readonly IEventLogger _originalLogger;
+            public T Logger => SnLog.Instance as T;
+
+            public LoggerSwindler()
+            {
+                _originalLogger = SnLog.Instance;
+                SnLog.Instance = Activator.CreateInstance<T>();
+            }
+            public LoggerSwindler(IEventLogger logger)
+            {
+                _originalLogger = SnLog.Instance;
+                SnLog.Instance = logger;
+            }
+            public void Dispose()
+            {
+                SnLog.Instance = _originalLogger;
             }
         }
     }


### PR DESCRIPTION
This PR contains the following features:
- contenttype system will start even if there is a missing handler or field in the system to support scenarios when there is a new database with old libraries on top of it
- auto-install patch feature in a non-released, switched off state