### PR TITLE
Fix/cors port

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -1,22 +1,23 @@
 ---
 title: "Cross-origin resource sharing"
-source_url: 'https://github.com/SenseNet/sensenet/docs/cors.md'
+source_url: 'https://github.com/SenseNet/sensenet/blob/master/docs/cors.md'
 category: Development
 version: v7.0
 tags: [CORS, authentication, jwt, login, origin, http headers, preflight, OData, REST]
+description: "In this article operators and developers may learn about CORS settings in sensenet and how we prevent cross-domain attacks."
 ---
 
 # Cross-origin resource sharing
 [Cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing) (CORS) is a technique that allows client-side web developers to access resources from a *different domain*. Shared JavaScript files or images are good examples for this. However cross-origin requests can also be used by hackers and malicious sites to access confidential information if a site is not protected against [Cross Site Request Forgery](http://hu.wikipedia.org/wiki/Cross-site_request_forgery) (CSRF) attacks. This is why browsers apply strict rules for these operations to prevent hackers from accessing the portal from external sites.
 
-> **sensenet ECM** supports CORS OData requests from **version 6.4** and CORS file download requests from **version 6.5.3**. In this article operators and developers may learn about CORS settings and how we prevent cross-domain attacks.}}
+> **sensenet** supports CORS OData requests from **version 6.4** and CORS file download requests from **version 6.5.3**. In this article operators and developers may learn about CORS settings and how we prevent cross-domain attacks.}}
 
-All the information on this page refers to our [OData REST API](/docs/odata-rest-api.md), as that is the most important entry point for client developers to the repository.
+All the information on this page refers to our [OData REST API](/docs/odata-rest-api), as that is the most important entry point for client developers to the repository.
 
 ## CORS basics
 The CORS specification defines two kinds of cross-origin request protocols:
 - simple CORS, using a single GET or POST request 
-- advanced CORS, using a *preflight request* (supported from sensenet ECM **version 6.5.4 patch 8**)
+- advanced CORS, using a *preflight request* (supported from sensenet **version 6.5.4 patch 8**)
 
 For details see the following article:
 - [CORS on Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
@@ -45,12 +46,12 @@ When a browser receives the response above, it will allow the JavaScript runtime
 > Please note that in this case the request was already executed successfully on the server, it is just the client-side JavaScript code that is not allowed to access the results. See the next section about how we use origin check to protect our portals against requests that would cause harm even if the client-side code does not receive the result.
 
 ### Origin check 
-In case of cross-domain requests all modern browsers send the *Origin* header to the server, containing the domain of the original page. Sensenet ECM always checks for the Origin header and if it is different than the requested domain and it is not included in a **whitelist**, the request will fail on the server without being able to do any harm. 
+In case of cross-domain requests all modern browsers send the *Origin* header to the server, containing the domain of the original page. sensenet always checks for the Origin header and if it is different than the requested domain and it is not included in a **whitelist**, the request will fail on the server without being able to do any harm. 
 
 > Unlike the old *Referer* header that contains the whole url, the *Origin* header contains only the domain and **it cannot be modified after the browser has sent the request**, meaning it is reliable.
 
 ## Settings
-You can manage CORS-related settings in the following [Settings](http://wiki.sensenet.com/Settings) content in the [Content Repository](/docs/content-repository.md)
+You can manage CORS-related settings in the following [Settings](http://wiki.sensenet.com/Settings) content in the [Content Repository](/docs/content-repository)
 - */Root/System/Settings/Portal.settings*
 
 ### Allowed origin domains
@@ -64,6 +65,18 @@ The list may contain internal or external domains:
 }
 ```
 
+##### Port handling
+You may define urls containing a specific port. In this case only the requests arriving from the defined urls will be allowed: requests from the same domain (`localhost`) but without a port will be denied.
+
+> If you are using sensenet on urls containing a port, you will have to define them here with exact port numbers. Simply adding `localhost` is not enough, there is no wildcard support for ports yet.
+
+```javascript
+{
+   AllowedOriginDomains: [ "localhost:1234", "localhost:5678" ]
+}
+```
+
+##### Wildcard
 It is also possible to open the Content Repository to *everyone* by providing a *wildcard* as the only allowed origin.
 
 ```javascript
@@ -73,9 +86,9 @@ It is also possible to open the Content Repository to *everyone* by providing a 
 ```
 
 ### Allowed methods and headers
-*from sensenet ECM version 7.0*
+*from sensenet version 7.0*
 
-If you need to, you may customize the list of allowed methods (http verbs) for CORS requests on your sensenet ECM instance. If something is missing from the default list, or you want to restrict the allowed request methods for security reasons, you can do so by providing the following line in the setting:
+If you need to, you may customize the list of allowed methods (http verbs) for CORS requests on your sensenet instance. If something is missing from the default list, or you want to restrict the allowed request methods for security reasons, you can do so by providing the following line in the setting:
 
 ```javascript
 {
@@ -106,7 +119,7 @@ Access-Control-Allow-Credentials: true
 ```
 
 ### Logging in using JWT authentication
-*from sensenet ECM version 7.0*
+*from sensenet version 7.0*
 
 To log in to a portal on a different domain than the current one (the target portal is where you want to send CORS requests), you can use [JWT authentication](/docs/web-token-authentication). The easiest way to do that is using the [Client JS API](/docs/tutorials/how-to-use-jwt-in-sn-client-js) instead of implementing the protocol by yourself.
 
@@ -114,13 +127,13 @@ To log in to a portal on a different domain than the current one (the target por
 All the protection and protocol above is related to browsers. Web requests made by *command line tools* do not contain these http headers and the response is not checked by the tool in any way. This means the whole cross-origin protection does not apply to command line tools.
 
 ## Examples
-To send a cross-origin request from JavaScript, you simply have to provide the absolute url of the resource you want to query (e.g. an OData request to a sensenet ECM portal) and tell the browser that you want it to send user credentials with the request:
+To send a cross-origin request from JavaScript, you simply have to provide the absolute url of the resource you want to query (e.g. an OData request to a sensenet portal) and tell the browser that you want it to send user credentials with the request:
 
 ```txt
 withCredentials: true
 ```
 
-The following examples send a CORS request to a sensenet ECM portal to get memos and create a new one. Of course you will have to be authenticated on the target site to make this work (see authentication section above for details).
+The following examples send a CORS request to a sensenet portal to get memos and create a new one. Of course you will have to be authenticated on the target site to make this work (see authentication section above for details).
 
 ```javascript
 // GET request: load memos from the Memos list

--- a/src/Services/Virtualization/HttpHeaderTools.cs
+++ b/src/Services/Virtualization/HttpHeaderTools.cs
@@ -289,10 +289,23 @@ namespace SenseNet.Portal.Virtualization
         {
             if (HttpContext.Current == null)
                 return true;
-            
+
             // Get the Origin header from the request, if it was sent by the browser.
             // Command-line tools or local html files will not send this.
             var originHeader = HttpContext.Current.Request.Headers[HEADER_ACESSCONTROL_ORIGIN_NAME];
+
+            return TrySetAllowedOriginHeader(originHeader,
+                HttpContext.Current.Request.Url,
+                () => Settings.GetValue<IEnumerable<string>>(PortalSettings.SETTINGSNAME,
+                    PortalSettings.SETTINGS_ALLOWEDORIGINDOMAINS,
+                    PortalContext.Current.ContextNodePath, new string[0]), out _);
+        }
+
+        internal static bool TrySetAllowedOriginHeader(string originHeader, Uri requestUri, 
+            Func<IEnumerable<string>> getCorsDomains, out string responseDomain)
+        {
+            responseDomain = null;
+
             if (string.IsNullOrEmpty(originHeader) || string.Compare(originHeader, "null", StringComparison.InvariantCultureIgnoreCase) == 0)
             {
                 SetAccessControlHeaders();
@@ -301,13 +314,15 @@ namespace SenseNet.Portal.Virtualization
 
             // We compare only the domain parts of the two urls, because interim servers
             // may change the scheme and port of the url (e.g. from https to http).
-            var currentDomain = HttpContext.Current.Request.Url.GetComponents(UriComponents.Host, UriFormat.SafeUnescaped);
+            var currentDomain = requestUri.GetComponents(UriComponents.Host, UriFormat.SafeUnescaped);
             var originDomain = string.Empty;
+
+            Uri origin = null;
             var error = false;
 
             try
             {
-                var origin = new Uri(originHeader.Trim(' '));
+                origin = new Uri(originHeader.Trim(' '));
                 originDomain = origin.GetComponents(UriComponents.Host, UriFormat.SafeUnescaped);
             }
             catch (Exception)
@@ -319,21 +334,27 @@ namespace SenseNet.Portal.Virtualization
             if (!error)
             {
                 // check if the request arrived from an external domain
-                if (string.Compare(currentDomain, originDomain, StringComparison.InvariantCultureIgnoreCase) != 0)
+                if (string.Compare(currentDomain, originDomain, StringComparison.InvariantCultureIgnoreCase) != 0 ||
+                    requestUri.Port != origin.Port)
                 {
                     // We allow requests from external domains only if they are registered in this whitelist.
-                    var corsDomains = Settings.GetValue<IEnumerable<string>>(PortalSettings.SETTINGSNAME, PortalSettings.SETTINGS_ALLOWEDORIGINDOMAINS, 
-                        PortalContext.Current.ContextNodePath, new string[0]);
+                    var corsDomains = getCorsDomains();
 
                     // try to find the domain in the whitelist (or the '*')
-                    var externalDomain = GetAllowedDomain(originDomain, corsDomains);
+                    var externalDomain = origin.IsDefaultPort
+                        ? GetAllowedDomain(originDomain, corsDomains)
+                        : GetAllowedDomain(originDomain + ":" + origin.Port, corsDomains);
 
                     if (!string.IsNullOrEmpty(externalDomain))
                     {
                         // Set the desired domain as allowed (or '*' if it is among the whitelisted domains). We cannot use 
                         // the value from the whitelist (e.g. 'example.com'), because the browser expects the full origin 
                         // (with schema and port, e.g. 'http://example.com:80').
-                        SetAccessControlHeaders(externalDomain == HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL ? HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL : originHeader);
+                        responseDomain = externalDomain == HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL
+                            ? HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL
+                            : originHeader;
+
+                        SetAccessControlHeaders(responseDomain);
                         return true;
                     }
 
@@ -349,7 +370,7 @@ namespace SenseNet.Portal.Virtualization
 
         internal static string GetAllowedDomain(string originDomain, IEnumerable<string> allowedDomains)
         {
-            return allowedDomains.FirstOrDefault(d =>
+            return allowedDomains?.FirstOrDefault(d =>
                 d == HEADER_ACESSCONTROL_ALLOWCREDENTIALS_ALL ||
                 string.Compare(d, originDomain, StringComparison.InvariantCultureIgnoreCase) == 0 ||
                 d.StartsWith("*.", StringComparison.Ordinal) && originDomain.EndsWith(d.Substring(1), 

--- a/src/Tests/SenseNet.Services.Tests/CorsTests.cs
+++ b/src/Tests/SenseNet.Services.Tests/CorsTests.cs
@@ -81,6 +81,19 @@ namespace SenseNet.Services.Tests
         }
 
         [TestMethod]
+        public void Cors_SetHeader_Port_Subdomain()
+        {
+            // allowed list contains the domain but does not contain the port
+            AssertOrigin("http://sub.example.com:123", DefaultRequestUri, new[] {"*.example.com"}, false, null);
+            // allowed list contains the domain but with a different port
+            AssertOrigin("http://sub.example.com:123", DefaultRequestUri, new[] {"*.example.com:456"}, false, null);
+
+            // allowed list contains a wildcard domain and the port
+            AssertOrigin("http://sub.example.com:123", DefaultRequestUri, new[] {"*.example.com:123"}, true,
+                "http://sub.example.com:123");
+        }
+
+        [TestMethod]
         public void Cors_SetHeader_Https()
         {
             AssertOrigin("https://otherdomain.com", DefaultRequestUri, new[] { "localhost" }, false, null);

--- a/src/Tests/SenseNet.Services.Tests/CorsTests.cs
+++ b/src/Tests/SenseNet.Services.Tests/CorsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SenseNet.Portal.Virtualization;
 using SenseNet.Tests;
 
@@ -7,6 +8,8 @@ namespace SenseNet.Services.Tests
     [TestClass]
     public class CorsTests : TestBase
     {
+        private static Uri DefaultRequestUri => new Uri("http://otherdomain.com/content/method");
+
         [TestMethod]
         public void Cors_AllowedDomain()
         {
@@ -34,6 +37,72 @@ namespace SenseNet.Services.Tests
 
             // invalid config
             Assert.AreEqual(null, HttpHeaderTools.GetAllowedDomain("abc", new[] { "*abc" }));
+        }
+
+        [TestMethod]
+        public void Cors_SetHeader_Simple()
+        {
+            AssertOrigin(null, null, null, true, null);
+            AssertOrigin("null", null, null, true, null);
+
+            AssertOrigin("http://example.com", DefaultRequestUri, null, false, null);
+            AssertOrigin("http://example.com", DefaultRequestUri, new[] { "otherdomain" }, false, null);
+            AssertOrigin("http://example.com", DefaultRequestUri, new[] { "*" }, true, "*");
+            AssertOrigin("http://example.com", DefaultRequestUri, new[] { "example.com" }, true, "http://example.com");
+        }
+
+        [TestMethod]
+        public void Cors_SetHeader_Port()
+        {
+            // strict behavior: allowed domain list contains only the domain, not the port of the origin
+            AssertOrigin("http://localhost:123", DefaultRequestUri, new[] { "localhost" }, false, null);
+
+            // not a real CORS request: urls are the same
+            AssertOrigin("http://localhost:123", GetLocalRequestUri(123), null, true, null);
+
+            // default port
+            AssertOrigin("http://localhost:80", GetLocalRequestUri(0), null, true, null);
+
+            // urls are the same plus existing allow list (makes no difference)
+            AssertOrigin("http://localhost:123", GetLocalRequestUri(123), new[] { "localhost" }, true, null);
+            // urls are the same plus allow list contains the url (makes no difference)
+            AssertOrigin("http://localhost:123", GetLocalRequestUri(123), new[] { "localhost:123" }, true, null);
+
+            // same domain, different port, allow list does not contain the port
+            AssertOrigin("http://localhost:123", GetLocalRequestUri(456), new[] { "localhost" }, false, null);
+
+            // different domain, allowed list contains the port
+            AssertOrigin("http://localhost:123", DefaultRequestUri, new[] { "localhost:123" }, true,
+                "http://localhost:123");
+
+            // same domain, different port, allowed list contains the port
+            AssertOrigin("http://localhost:123", GetLocalRequestUri(456), new[] { "localhost:123" }, true,
+                "http://localhost:123");
+        }
+
+        [TestMethod]
+        public void Cors_SetHeader_Https()
+        {
+            AssertOrigin("https://otherdomain.com", DefaultRequestUri, new[] { "localhost" }, false, null);
+            AssertOrigin("https://otherdomain.com:443", new Uri($"https://otherdomain.com/content/method"),
+                new[] {"localhost"}, true, null);
+            AssertOrigin("https://example.com:443", DefaultRequestUri, new[] {"example.com"}, true,
+                "https://example.com:443");
+        }
+
+        private static void AssertOrigin(string originHeader, Uri requestUri,string[] allowedOrigins, bool expectedResult, string expectedDomain)
+        {
+            var result = HttpHeaderTools.TrySetAllowedOriginHeader(originHeader, requestUri, 
+                () => allowedOrigins, out var domain);
+
+            Assert.AreEqual(expectedResult, result);
+            Assert.AreEqual(expectedDomain, domain);
+        }
+        private static Uri GetLocalRequestUri(int port = 0)
+        {
+            var portText = port > 0 ? ":" + port : string.Empty;
+
+            return new Uri($"http://localhost{portText}/content/method");
         }
     }
 }


### PR DESCRIPTION
From now on it is possible to define [allowed origin domains](https://community.sensenet.com/docs/cors/) with a port number. This allows developers to work with sensenet in a local environment, where `localhost:1234`-style urls are very common.