### PR TITLE
Fixed grammatical errors / typos

### DIFF
--- a/docs/web-token-authentication.md
+++ b/docs/web-token-authentication.md
@@ -231,7 +231,7 @@ HTTP response with status 401 (Unauthorized). On the diagram it is used to sign 
 `<accessHeadAndPayload>, <refreshHeadAndPayload>`: base64 and URL encoded strings.
 
 The access head and payload are the public part of a token, that consists of two parts separated by a full stop.
-The first one is a technical like header that you do not have to care about. The second one - the payload - contains claims about the authenticated user and about some authentication concerning data. Once the payload has been decoded from base64 it will be a string representation of a JSON object, so it can be easily use in Javascript.
+The first one is a technical like header that you do not have to care about. The second one - the payload - contains claims about the authenticated user and about some authentication concerning data. Once the payload has been decoded from base64 it will be a string representation of a JSON object, so it can be easily used in Javascript.
 
 **Example of a typical payload:**  
 ```json

--- a/docs/xss-protection.md
+++ b/docs/xss-protection.md
@@ -33,7 +33,7 @@ Fields will always store data in the same format as received from input. The fol
 <%# DataBinder.Eval(Container, "HtmlData") %>
 ```
 
-Where RawData outputs raw data, TextData uses full encoding of data and HtmlData use sanitization of Field data. You can also use the simple *Data* accessor:
+Where RawData outputs raw data, TextData uses full encoding of data and HtmlData uses sanitization of Field data. You can also use the simple *Data* accessor:
 
 ```csharp
 <%# DataBinder.Eval(Container, "Data") %>


### PR DESCRIPTION
Signed-off-by: Akshit Sarin <akshitsarin99@gmail.com>

• 'dinamically' to 'dynamically'
• 'be easily *use* in JavaScript' to 'be easily *used* in JavaScript'