### PR TITLE
Corrected typos and grammar errors in documentation

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -24,7 +24,7 @@ where
 
 #### Application inheritance
 
-Applications can be *overridden* in a subtree by placing an Application of the same name under an _(apps)_ folder that is placed at a deeper level in the [Content Repository](content-repository.md) and also by using the `This` keyword as contenttypename. See examples and refer to [Smart Application Model](smart-application-model.md) for a details.
+Applications can be *overridden* in a subtree by placing an Application of the same name under an _(apps)_ folder that is placed at a deeper level in the [Content Repository](content-repository.md) and also by using the `This` keyword as contenttypename. See examples and refer to [Smart Application Model](smart-application-model.md) for details.
 
 ### Applications and Actions
 
@@ -37,7 +37,7 @@ The Application is resolved then using [Smart Application Model](smart-applicati
 
 ### Application types
 
-Altough an Application for a [Content Type](content-type.md) is usually defined as a [Smart Page](smart-pages.md) to present the [Content](content.md), there are several other Application types defined in the system. An RssApplication for example will return the Rss feed corresponding to the addressed [Content](content.md) in the response. The base [Content Type](content-type.md) for Application types can be found under _/Root/System/Schema/ContentTypes/GenericContent/Application_. Here is a few examples of pre-defined Application types:
+Although an Application for a [Content Type](content-type.md) is usually defined as a [Smart Page](smart-pages.md) to present the [Content](content.md), there are several other Application types defined in the system. An RssApplication for example will return the Rss feed corresponding to the addressed [Content](content.md) in the response. The base [Content Type](content-type.md) for Application types can be found under _/Root/System/Schema/ContentTypes/GenericContent/Application_. Here are a few examples of pre-defined Application types:
 
 - **Page**: defines a page layout to be rendered - when used with [Context bound Portlets](context-bound-portlets.md) it is referred to as a [Smart Page](smart-pages.md).
 - **ApplicationOverride**: it can be used to override Fields of an existing Application (Smart Page), without modifying the page layout
@@ -56,12 +56,12 @@ There is a special type of application that is a placeholder for defining an [OD
 Since an Application itself is a [Content](content.md) in the [Content Repository](content-repository.md), it has got Fields that describe its behavior. These Fields include the following (only listing the most important Fields):
 
 - **Scenario**: the list of scenario 'keywords' that define the places where action links referring the Application will appear. For example an Application with _ListItem_ scenario can be initiated from the dropdown menu in various lists; an Application with `ExploreActions` scenario appears in the [Actions](action.md) menu of [Explore](content-explorer.md). You can read more about this at the [Action](action.md) reference wiki page.
-- **ActionTypeName**: the .Net type of action (a class name) that is created when the Application is referred via an [Action](action.md). A few example for built-in types:
+- **ActionTypeName**: the .Net type of action (a class name) that is created when the Application is referred via an [Action](action.md). A few examples for built-in types:
   - _UrlAction_ (default): a simple link is created with `?action` url parameter that points to the Application name.
   - _UploadAction_: a `UrlAction` for containers with a custom evaluation: the upload link becomes disabled if the context folder does not allow File types to be added as child Content.
   - _CopyToAction_: a simple link is created that brings up a Content Picker where destination Folder can be selected. Context [Content](content.md) is then copied using the `CopyToTarget` Application.
 - **Disabled**: setting it to *true* makes the Application 'disappear' and cannot be invoked through an action link. Applications on higher levels with the same name (those that were overridden by this specific instance) remain functional and take part in the Application path resolution logic.
-- **Clear**: similar to Disabled, except that it hides higher level, overrided Applications of the same name as well. This is useful for *disabling an Application for a subtree* when the Application has been defined on a higher level (eg. in _/Root/(apps)_) and is available for [Content](content.md) in several subtrees - but it should not appear for [Content](content.md) that are under a specific subtree.
+- **Clear**: similar to Disabled, except that it hides higher level, overridden Applications of the same name as well. This is useful for *disabling an Application for a subtree* when the Application has been defined on a higher level (eg. in _/Root/(apps)_) and is available for [Content](content.md) in several subtrees - but it should not appear for [Content](content.md) that are under a specific subtree.
 - **Icon**: name of the Icon for the Application. This icon appears next to action links if it is enabled by the control that renders the link. Icons reside in the _/Root/Global/images/icons_ folder.
 - **StyleHint**: an optional string property that can be interpreted by a custom renderer. Built-in renderers do not use this property.
 - **RequiredPermissions**: multiselect list that defines the permissions that are required on the target Content for the Application to be applicable to it. For example for an Edit Application one could specify the Edit permission to be required on the [Content](content.md), so that for users that don't possess sufficient rights the Edit link will be disabled and thus cannot navigate to a Content's Edit Application. Besides the permissions specified here there are some necessary basic permission settings for a [Content](content.md) to be presented with an Application.

--- a/docs/binary-field.md
+++ b/docs/binary-field.md
@@ -8,11 +8,11 @@ tags: [fields, binary]
 
 # Binary Field
 
-Binary Field is used for storing binary data. This is the most important Field defined on the File Content Type: after uploading a file the binary content of your file will be stored in a Binary field.
+Binary Field is used for storing binary data. This is the most important Field defined on the File Content Type: after uploading a file the binary content of your file will be stored in a Binary Field.
 
-In a Binary field any kind of binary data can be stored without length restrictions. This is very useful, when you want to store uploaded files on your portal. The following apply to the behavior of the field:
+In a Binary Field any kind of binary data can be stored without length restrictions. This is very useful when you want to store uploaded files on your portal. The following apply to the behavior of the field:
 
-- **Import/Export**: binary Field data can be exported to a single file / imported from a single file.
+- **Import/Export**: Binary Field data can be exported to a single file / imported from a single file.
 
 ## Field handler
 
@@ -29,7 +29,7 @@ Usage in CTD:
 
 ## Supported Field Controls
 
-- [Binary Field Control](binary-fieldcontrol.md): a complex field control that provides interface to upload/download binary content or edit textual content in a textarea.
+- [Binary Field Control](binary-fieldcontrol.md): a complex field control that provides an interface to upload/download binary content or edit textual content in a textarea.
 
 ## Configuration
 
@@ -55,7 +55,7 @@ Fully featured example:
 </Field>
 ```
 
-The above example configures the Binary field so that:
+The above example configures the Binary Field so that:
 
 - the field is editable (not read-only)
 - filling the field is not necessary

--- a/docs/binary-fieldcontrol.md
+++ b/docs/binary-fieldcontrol.md
@@ -18,7 +18,7 @@ With Binary Field Control the binary data of a Content can be added/modified. De
 
 - the displayed Content is a [Content Type](content-type.md),
 - the displayed Content has an extension that is included in the web.config's *EditSourceExtensions* entry of the *sensenet/webApplication* section,
-- otherwise when the *IsText* property in the underyling [Binary Field's](binary-field.md) [Field Setting](field-setting.md) is set to true.
+- otherwise when the *IsText* property in the underlying [Binary Field's](binary-field.md) [Field Setting](field-setting.md) is set to true.
 When a textarea is rendered it can be displayed as a highlighted editor of bigger size using the FullScreenText property.
 
 ## Supported Field types
@@ -31,7 +31,7 @@ When a textarea is rendered it can be displayed as a highlighted editor of bigge
 
 ## Templates
 
-Binary field control renders the name of the assigned file as a hyperlink in Browse mode. In Edit mode a fileupload control or a textarea control is rendered.
+Binary Field Control renders the name of the assigned file as a hyperlink in Browse mode. In Edit mode a fileupload control or a textarea control is rendered.
 
 ### Browse view template
 

--- a/docs/blob-provider.md
+++ b/docs/blob-provider.md
@@ -9,7 +9,7 @@ description: This article describes the concept of our blob storage and the cust
 
 # Blob provider
 
-In **sensenet** all files are stored in the main [Content Repository](content-repository.md) database by default. All binaries, along with their metadata. In larger projects this can lead to a huge database, which requires a *large data storage* and sometimes additional *server licences*. To aid this scenario sensenet allows you to **store binaries outside of the database**, in an external storage. This article describes the concept of our blob storage and the customization options. Available blob providers for the *Enterprise Edition*:
+In **sensenet** all files are stored in the main [Content Repository](content-repository.md) database by default. All binaries, along with their metadata. In larger projects this can lead to a huge database, which requires a *large data storage* and sometimes additional *server licenses*. To aid this scenario sensenet allows you to **store binaries outside of the database**, in an external storage. This article describes the concept of our blob storage and the customization options. Available blob providers for the *Enterprise Edition*:
 
 -   [MongoDB blob provider](https://community.sensenet.com/docs/mongodb-provider)
 -   [Azure blob provider](https://community.sensenet.com/docs/azureblob-provider) *(soon to be released)*
@@ -28,7 +28,7 @@ Upper layers do not know anything about the underlying storage: the Content bina
 
 ### Migration
 
-By default everything is stored in the database. When you create a custom external blob provider (and define it in the configuration), from than on *new files* will be saved into that external storage. If you want your old files to be moved to the new storage, you either have to wait for them to be migrated when their binary is saved again, or you'll have to create a tool (preferably an SnAdmin package) that iterates through the files and saves them programmatically.
+By default everything is stored in the database. When you create a custom external blob provider (and define it in the configuration), from then on *new files* will be saved into that external storage. If you want your old files to be moved to the new storage, you either have to wait for them to be migrated when their binary is saved again, or you'll have to create a tool (preferably an SnAdmin package) that iterates through the files and saves them programmatically.
 
 ### Backup
 
@@ -56,7 +56,7 @@ The built-in blob provider will always be there as a fallback. Currently it supp
 
 ## Custom blob provider
 
-It is possible to implement a custom blob storage provider that sends files to an externak storage. For a sample implementation (a local file storage provider) check the following article:
+It is possible to implement a custom blob storage provider that sends files to external storage. For a sample implementation (a local file storage provider) check the following article:
 
 - [How to create an external blob provider](https://community.sensenet.com/docs/tutorials/how-to-create-an-external-blob-provider)
 

--- a/docs/built-in-odata-actions-and-functions.md
+++ b/docs/built-in-odata-actions-and-functions.md
@@ -622,7 +622,7 @@ It is possible to send authentication requests using this action. You provide th
 ```
 
 ```diff
-- As the username and password is sent in clear text, always send these kinds of requests throuigh HTTPS.
+- As the username and password is sent in clear text, always send these kinds of requests through HTTPS.
 ```
 
 ```js


### PR DESCRIPTION
Made `application.md`, `binary-field.md`, `binary-fieldcontrol.md`, `blob-provider.md`, and `built-in-odata-actions-and-functions.md` better by fixing typos and grammar mistakes.