### PR TITLE
PortalPrincipal is inherited from ClaimsIdentity to make it compatible with AspNetCore HttpContext.User

### DIFF
--- a/src/ContentRepository/Security/PortalPrincipal.cs
+++ b/src/ContentRepository/Security/PortalPrincipal.cs
@@ -21,11 +21,6 @@ namespace SenseNet.ContentRepository.Security
         }
 
         /// <summary>
-        /// Gets the primary SenseNet claims identity associated with this claims principal.
-        /// </summary>
-        public new IUser Identity => (IUser)base.Identity;
-
-        /// <summary>
         /// Returns a value that indicates whether the entity (user) represented by this claims principal is in the specified role.
         /// </summary>
         /// <param name="role">The role for which to check.</param>

--- a/src/ContentRepository/Security/PortalPrincipal.cs
+++ b/src/ContentRepository/Security/PortalPrincipal.cs
@@ -1,34 +1,39 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Security.Principal;
+using System.Security.Claims;
 using SenseNet.ContentRepository.Storage.Security;
 
 namespace SenseNet.ContentRepository.Security
 {
-    public class PortalPrincipal : IPrincipal
+    /// <summary>
+    /// An <see cref="System.Security.Principal.IPrincipal" /> implementation that supports multiple claims-based identities.
+    /// </summary>
+    /// <seealso cref="System.Security.Claims.ClaimsPrincipal" />
+    public class PortalPrincipal : ClaimsPrincipal
     {
-        private IUser _user;
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortalPrincipal" /> class.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <exception cref="ArgumentNullException">user - The user parameter cannot be null. Use 'User.Visitor' instead.</exception>
         public PortalPrincipal(IUser user)
+            : base(user ?? throw new ArgumentNullException(nameof(user), "User cannot be null. Use 'User.Visitor' instead."))
         {
-            if (user == null)
-                throw new ArgumentNullException("user", "The user parameter cannot be null. Use 'User.Visitor' instead.");
-            _user = user;
         }
 
-        #region IPrincipal Members
+        /// <summary>
+        /// Gets the primary SenseNet claims identity associated with this claims principal.
+        /// </summary>
+        public new IUser Identity => (IUser)base.Identity;
 
-        public IIdentity Identity
-        {
-            get { return _user; }
-        }
-
-        public bool IsInRole(string role)
-        {
-            throw new NotSupportedException("Role management is not supported.");
-        }
-
-        #endregion
+        /// <summary>
+        /// Returns a value that indicates whether the entity (user) represented by this claims principal is in the specified role.
+        /// </summary>
+        /// <param name="role">The role for which to check.</param>
+        /// <returns>
+        /// true if claims principal is in the specified role; otherwise, false.
+        /// </returns>
+        /// <exception cref="NotSupportedException">Role management is not supported.</exception>
+        public override bool IsInRole(string role)
+            => throw new NotSupportedException("Role management is not supported.");
     }
 }

--- a/src/ContentRepository/Security/PortalPrincipal.cs
+++ b/src/ContentRepository/Security/PortalPrincipal.cs
@@ -1,3 +1,6 @@
+// Copyright (c) SenseNet. All rights reserved.
+// Licensed under the GNU GPL License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Security.Claims;
 using SenseNet.ContentRepository.Storage.Security;

--- a/src/ContentRepository/Security/PortalPrincipal.cs
+++ b/src/ContentRepository/Security/PortalPrincipal.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Claims;
+using System.Security.Principal;
 using SenseNet.ContentRepository.Storage.Security;
 
 namespace SenseNet.ContentRepository.Security
@@ -13,15 +14,23 @@ namespace SenseNet.ContentRepository.Security
     /// <seealso cref="System.Security.Claims.ClaimsPrincipal" />
     public class PortalPrincipal : ClaimsPrincipal
     {
+        private readonly IUser _user;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PortalPrincipal" /> class.
         /// </summary>
-        /// <param name="user">The user.</param>
+        /// <param name="user">The primary user identity associated with this claims principal.</param>
         /// <exception cref="ArgumentNullException">user - The user parameter cannot be null. Use 'User.Visitor' instead.</exception>
         public PortalPrincipal(IUser user)
-            : base(user ?? throw new ArgumentNullException(nameof(user), "User cannot be null. Use 'User.Visitor' instead."))
+            : base(user)
         {
+            _user = user ?? throw new ArgumentNullException(nameof(user), "User cannot be null. Use 'User.Visitor' instead.");
         }
+
+        /// <summary>
+        /// Gets the primary claims identity associated with this claims principal.
+        /// </summary>
+        public override IIdentity Identity => _user;
 
         /// <summary>
         /// Returns a value that indicates whether the entity (user) represented by this claims principal is in the specified role.


### PR DESCRIPTION
This PR turns `PortalPrincipal` into a `ClaimsPrincipal` to make it compatible with AspNetCore Http abstractions (see [HttpContext.User](https://github.com/aspnet/AspNetCore/blob/master/src/Http/Http.Abstractions/src/HttpContext.cs#L45)). Unlike _System.Web.HttpContext_, _Microsoft.AspNetCore.Http.HttpContext_ works with claim-based principal by default.

- Enables us to integrate _IdentityServer4 AccessTokenValidation_ and set the correct `PortalPrincipal` when access token validation has completed without any errors.
- Claims, which can even be extended with custom data on validation, get available within the entire application by dependency injection [IHttpContextAccessor](https://github.com/aspnet/AspNetCore/blob/master/src/Http/Http.Abstractions/src/IHttpContextAccessor.cs).