### PR TITLE
Set previewprovider and avoid workflow query.

### DIFF
--- a/src/ContentRepository/GenericContent.cs
+++ b/src/ContentRepository/GenericContent.cs
@@ -1804,6 +1804,15 @@ namespace SenseNet.ContentRepository
 
         private void UpdateRelatedWorkflows()
         {
+            // Update workflows only if the Workflow component is installed - otherwise
+            // the query below would lead to an Unknown field exception.
+            if (!RepositoryVersionInfo.Instance.Components.Any(c =>
+                string.Equals(c.ComponentId, "SenseNet.Workflow", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                _keepWorkflowsAlive = false;
+                return;
+            }
+
             // Certain workflows (e.g. approving) are designed to be aborted when a Content changes, but in case
             // certain system operations (e.g. updating a page count on a document) this should not happen.
             // So after saving the Content we update the related workflows to contain the same timestamp

--- a/src/ContentRepository/Preview/DocumentPreviewProvider.cs
+++ b/src/ContentRepository/Preview/DocumentPreviewProvider.cs
@@ -126,52 +126,12 @@ namespace SenseNet.Preview
 
         // ===================================================================================================== Static provider instance
 
-        private static DocumentPreviewProvider _current;
-        private static readonly object _lock = new object();
-        private static bool _isInitialized;
-        public static DocumentPreviewProvider Current
-        {
-            get
-            {
-                // This property has a duplicate in the Storage layer in the PreviewProvider
-                // class. If you change this, please propagate changes there.
-
-                if ((_current == null) && (!_isInitialized))
-                {
-                    lock (_lock)
-                    {
-                        if ((_current == null) && (!_isInitialized))
-                        {
-                            try
-                            {
-                                _current = (DocumentPreviewProvider)TypeResolver.CreateInstance(Providers.DocumentPreviewProviderClassName);
-                            }
-                            catch (TypeNotFoundException) // rethrow
-                            {
-                                throw new ConfigurationErrorsException(string.Concat(SR.Exceptions.Configuration.Msg_DocumentPreviewProviderImplementationDoesNotExist, ": ", Providers.DocumentPreviewProviderClassName));
-                            }
-                            catch (InvalidCastException) // rethrow
-                            {
-                                throw new ConfigurationErrorsException(string.Concat(SR.Exceptions.Configuration.Msg_InvalidDocumentPreviewProviderImplementation, ": ", Providers.DocumentPreviewProviderClassName));
-                            }
-                            finally
-                            {
-                                _isInitialized = true;
-                            }
-
-                            if (_current == null)
-                                SnLog.WriteInformation("DocumentPreviewProvider not present.");
-                            else
-                                SnLog.WriteInformation("DocumentPreviewProvider created: " + _current.GetType().FullName, properties: new Dictionary<string, object>
-                                {
-                                    { "SupportedTaskNames", string.Join(", ", _current.GetSupportedTaskNames())}
-                                });
-                        }
-                    }
-                }
-                return _current;
-            }
-        }
+        // This property has a duplicate in the Storage layer in the PreviewProvider
+        // class. If you change this, please propagate changes there.
+        // In this layer we assume that the provider is an instance of the DocumentPreviewProvider
+        // class that we are in now. The setter extension methods in the Preview package
+        // will make sure this is true.
+        public static DocumentPreviewProvider Current => (DocumentPreviewProvider)Providers.Instance.PreviewProvider;
 
         // ===================================================================================================== Helper methods
 

--- a/src/Storage/Configuration/Providers.cs
+++ b/src/Storage/Configuration/Providers.cs
@@ -207,6 +207,23 @@ namespace SenseNet.Configuration
         }
         #endregion
 
+        #region private Lazy<IPreviewProvider> _previewProvider = new Lazy<IPreviewProvider>
+        private Lazy<IPreviewProvider> _previewProvider = new Lazy<IPreviewProvider>(() => 
+            CreateProviderInstance<IPreviewProvider>(DocumentPreviewProviderClassName,"DocumentPreviewProvider"));
+
+        /// <summary>
+        /// Preview provider instance. Do NOT set this property directly,
+        /// because it has to be an instance of the DocumentPreviewProvider class
+        /// that resides in the ContentRepository layer.
+        /// Use the extension methods on the IRepositoryBuilder api instead.
+        /// </summary>
+        public virtual IPreviewProvider PreviewProvider
+        {
+            get => _previewProvider.Value;
+            set { _previewProvider = new Lazy<IPreviewProvider>(() => value); }
+        }
+        #endregion
+
         #region private Lazy<IMessageProvider> _securityMessageProvider = new Lazy<IMessageProvider>
         private Lazy<IMessageProvider> _securityMessageProvider = new Lazy<IMessageProvider>(() =>
         {

--- a/src/Storage/PreviewProvider.cs
+++ b/src/Storage/PreviewProvider.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Configuration;
-using SenseNet.Configuration;
-using SenseNet.Diagnostics;
-using SenseNet.Tools;
+﻿using SenseNet.Configuration;
 
+// ReSharper disable once CheckNamespace
 namespace SenseNet.ContentRepository.Storage
 {
     public interface IPreviewProvider
@@ -17,51 +14,12 @@ namespace SenseNet.ContentRepository.Storage
     internal class PreviewProvider
     {
         // ============================================================================== Static internal API
-
-        private static IPreviewProvider _previewProvider;
-        private static readonly object _previewLock = new object();
-        private static bool _isInitialized;
-
+        
         /// <summary>
-        /// Instance of a DocumentPreviewProvider in the Storage layer. This property is a duplicate of the Current property of the DocumentPreviewProvider class.
+        /// Instance of a DocumentPreviewProvider in the Storage layer. This property is a duplicate
+        /// of the Current property of the DocumentPreviewProvider class.
         /// </summary>
-        private static IPreviewProvider Current
-        {
-            get
-            {
-                if ((_previewProvider == null) && (!_isInitialized))
-                {
-                    lock (_previewLock)
-                    {
-                        if ((_previewProvider == null) && (!_isInitialized))
-                        {
-                            try
-                            {
-                                _previewProvider = (IPreviewProvider)TypeResolver.CreateInstance(Providers.DocumentPreviewProviderClassName);
-                            }
-                            catch (TypeNotFoundException) // rethrow
-                            {
-                                throw new ConfigurationErrorsException(string.Concat(SR.Exceptions.Configuration.Msg_DocumentPreviewProviderImplementationDoesNotExist, ": ", Providers.DocumentPreviewProviderClassName));
-                            }
-                            catch (InvalidCastException) // rethrow
-                            {
-                                throw new ConfigurationErrorsException(string.Concat(SR.Exceptions.Configuration.Msg_InvalidDocumentPreviewProviderImplementation, ": ", Providers.DocumentPreviewProviderClassName));
-                            }
-                            finally
-                            {
-                                _isInitialized = true;
-                            }
-
-                            if (_previewProvider == null)
-                                SnLog.WriteInformation("DocumentPreviewProvider not present.");
-                            else
-                                SnLog.WriteInformation("DocumentPreviewProvider created: " + _previewProvider.GetType().FullName);
-                        }
-                    }
-                }
-                return _previewProvider;
-            }
-        }
+        private static IPreviewProvider Current => Providers.Instance.PreviewProvider;
 
         internal static bool HasPreviewPermission(NodeHead nodeHead)
         {


### PR DESCRIPTION
- Document preview provider instance can be set from outside.
- Update workflows only if the Workflow component is installed.