### PR TITLE
Expand binary field and a test.

### DIFF
--- a/src/OData/ExpanderProjector.cs
+++ b/src/OData/ExpanderProjector.cs
@@ -241,6 +241,8 @@ namespace SenseNet.OData
         {
             if (!(field is ReferenceField refField))
             {
+                if (field is BinaryField binaryField)
+                    return ProjectBinaryField(binaryField);
                 if (!(field is AllowedChildTypesField allowedChildTypesField))
                     return null;
                 return ProjectMultiRefContents(allowedChildTypesField.GetData(), expansion, selection, httpContext);
@@ -254,6 +256,11 @@ namespace SenseNet.OData
             return isMultiRef
                 ? ProjectMultiRefContents(refField.GetData(), expansion, selection, httpContext)
                 : (object)ProjectSingleRefContent(refField.GetData(), expansion, selection, httpContext);
+        }
+        private object ProjectBinaryField(BinaryField field)
+        {
+            return RepositoryTools.GetStreamString(
+                field.Content.ContentHandler.GetBinary(field.Name).GetStream());
         }
         private List<ODataEntity> ProjectMultiRefContents(object references, List<Property> expansion, List<Property> selection, HttpContext httpContext)
         {

--- a/src/OData/ExpanderProjector.cs
+++ b/src/OData/ExpanderProjector.cs
@@ -245,7 +245,7 @@ namespace SenseNet.OData
             if (!(field is ReferenceField refField))
             {
                 if (field is BinaryField binaryField)
-                    return ProjectBinaryField(binaryField, httpContext);
+                    return TextFileHandler.ProjectBinaryField(binaryField, selection.Select(x=>x.Name).ToArray(), httpContext);
                 if (!(field is AllowedChildTypesField allowedChildTypesField))
                     return null;
                 return ProjectMultiRefContents(allowedChildTypesField.GetData(), expansion, selection, httpContext);
@@ -259,35 +259,6 @@ namespace SenseNet.OData
             return isMultiRef
                 ? ProjectMultiRefContents(refField.GetData(), expansion, selection, httpContext)
                 : (object)ProjectSingleRefContent(refField.GetData(), expansion, selection, httpContext);
-        }
-        private object ProjectBinaryField(BinaryField field, HttpContext httpContext)
-        {
-            var maxSize = 500 * 1024;
-
-            var stream = DocumentBinaryProvider.Instance.GetStream(field.Content.ContentHandler, 
-                field.Name, httpContext, out var contentType, out var binaryFileName);
-
-            return new
-            {
-                fileName = binaryFileName.ToString(),
-                contentType = contentType,
-                truncated = stream.Length > maxSize,
-                text = ReadBinaryContent(contentType, maxSize, stream)
-            };
-        }
-        private string ReadBinaryContent(string contentType, int maxSize, Stream stream)
-        {
-            var size = Convert.ToInt32(Math.Min(stream.Length, maxSize));
-
-            var buffer = new char[size];
-            using (var reader = new StreamReader(stream, Encoding.UTF8))
-                reader.ReadBlockAsync(buffer, 0, size)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
-
-            while (size > 0 && buffer[size - 1] == (char) 0)
-                size--;
-
-            return new string(buffer, 0, size);
         }
 
         private List<ODataEntity> ProjectMultiRefContents(object references, List<Property> expansion, List<Property> selection, HttpContext httpContext)

--- a/src/OData/SimpleExpanderProjector.cs
+++ b/src/OData/SimpleExpanderProjector.cs
@@ -131,6 +131,8 @@ namespace SenseNet.OData
         {
             if (!(field is ReferenceField refField))
             {
+                if (field is BinaryField binaryField)
+                    return TextFileHandler.ProjectBinaryField(binaryField, null, httpContext);
                 if (!(field is AllowedChildTypesField allowedChildTypesField))
                     return null;
                 return ProjectMultiRefContents(allowedChildTypesField.GetData(), expansion, httpContext);

--- a/src/OData/TextFileHandler.cs
+++ b/src/OData/TextFileHandler.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using Microsoft.AspNetCore.Http;
+using SC = SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Fields;
+using SenseNet.OData.Metadata.Model;
+using SenseNet.Portal.Virtualization;
+
+namespace SenseNet.OData
+{
+
+    internal class TextFileHandler
+    {
+        private static class Expansion
+        {
+            public static string FileName = "FileName";
+            public static string ContentType = "ContentType";
+            public static string Length = "Length";
+            public static string Message = "Message";
+            public static string Text = "Text";
+        }
+        private static class Settings
+        {
+            public static string SettingsName = "TextFiles";
+            public static string Extensions = "Extensions";
+            public static string MaxExpandableSize = "MaxExpandableSize";
+        }
+
+        private static readonly string DefaultTextFileExtensions = "md txt js";
+
+        private static string[] TextFileExtensions => new Lazy<string[]>(() =>
+            SC.Settings.GetValue(
+                Settings.SettingsName,
+                Settings.Extensions,
+                null, DefaultTextFileExtensions).Split(' ')).Value;
+
+        private static int MaxExpandableSize => new Lazy<int>(() =>
+            SC.Settings.GetValue(
+                Settings.SettingsName,
+                Settings.MaxExpandableSize,
+                null, 500 * 1024)).Value;
+
+        internal static object ProjectBinaryField(BinaryField field, string[] selection, HttpContext httpContext)
+        {
+            var allSelected = selection == null || selection.Length == 0 || selection[0] == "*";
+
+            var stream = DocumentBinaryProvider.Instance.GetStream(field.Content.ContentHandler,
+                field.Name, httpContext, out var contentType, out var binaryFileName);
+
+            string message;
+            var contentName = field.Content.Name;
+            var extension = Path.GetExtension(contentName)?.Trim('.');
+
+            if (stream.Length > MaxExpandableSize)
+                message = $"Size limit exceed. Limit: {MaxExpandableSize}, size: {stream.Length}";
+            else if (!TextFileExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                message = $"*.{extension} is not a text file.";
+            else
+                message = string.Empty;
+
+            var result = new Dictionary<string, object>();
+            if (allSelected || selection.Contains(Expansion.FileName))
+                result.Add(Expansion.FileName, binaryFileName.ToString());
+            if (allSelected || selection.Contains(Expansion.ContentType))
+                result.Add(Expansion.ContentType, contentType);
+            if (allSelected || selection.Contains(Expansion.Length))
+                result.Add(Expansion.Length, stream.Length);
+            if (allSelected || selection.Contains(Expansion.Message))
+                result.Add(Expansion.Message, message);
+            if (allSelected || selection.Contains(Expansion.Text))
+                result.Add(Expansion.Text, string.IsNullOrEmpty(message) ? ReadBinaryContent(stream) : null);
+            return result;
+        }
+        private static string ReadBinaryContent(Stream stream)
+        {
+            var size = Convert.ToInt32(stream.Length);
+
+            var buffer = new char[size];
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
+                reader.ReadBlockAsync(buffer, 0, size)
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
+
+            // cut trailing zero bytes
+            while (size > 0 && buffer[size - 1] == (char)0)
+                size--;
+
+            return new string(buffer, 0, size);
+        }
+
+    }
+}

--- a/src/OData/TextFileHandler.cs
+++ b/src/OData/TextFileHandler.cs
@@ -28,7 +28,7 @@ namespace SenseNet.OData
             public static string MaxExpandableSize = "MaxExpandableSize";
         }
 
-        private static readonly string[] DefaultTextFileExtensions = { "md", "txt", "js" };
+        private static readonly string[] DefaultTextFileExtensions = { "md", "txt", "js", "settings" };
 
         private static string[] TextFileExtensions => SC.Settings.GetValue(
             Settings.SettingsName,

--- a/src/OData/TextFileHandler.cs
+++ b/src/OData/TextFileHandler.cs
@@ -30,7 +30,7 @@ namespace SenseNet.OData
             public static string MaxExpandableSize = "MaxExpandableSize";
         }
 
-        private static readonly string DefaultTextFileExtensions = "md txt js";
+        private static readonly string DefaultTextFileExtensions = "md txt js settings";
 
         private static string[] TextFileExtensions => new Lazy<string[]>(() =>
             SC.Settings.GetValue(

--- a/src/Tests/SenseNet.ODataTests/ODataChildrenTests.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataChildrenTests.cs
@@ -271,7 +271,7 @@ namespace SenseNet.ODataTests
 
                 // ASSERT
                 var entities = GetEntities(response);
-                var texts = entities.ToDictionary(x => x.Name, x => x.AllProperties["Binary"].ToString() ?? "null");
+                var texts = entities.ToDictionary(x => x.Name, x => ((JObject)x.AllProperties["Binary"])["text"].ToString() ?? "null");
                 foreach (var name in expectedTexts.Keys)
                     Assert.AreEqual(name + ":" + expectedTexts[name], name + ":" + texts[name]);
             }).ConfigureAwait(false);


### PR DESCRIPTION
The feature can be also tested by a link something like this:
`https://<sn-testapp>/odata.svc/Root/System/Settings?metadata=no&$expand=Binary&$select=Name,Type,Binary`

The selection chain also can be used: `$select=Binary/Text,Binary/Message`