### PR TITLE
Fix/980 upload text

### DIFF
--- a/src/Services.Core/Operations/UploadHandler.cs
+++ b/src/Services.Core/Operations/UploadHandler.cs
@@ -269,8 +269,11 @@ namespace SenseNet.Services.Core.Operations
             }
             else
             {
-                // handle uploaded chunks/stream
-                var file = _httpContext.Request.Form.Files.Count > 0 ? _httpContext.Request.Form.Files[0] : null;
+                // handle uploaded chunks/stream/text
+                IFormFile file = null;
+                if(string.IsNullOrEmpty(FileText))
+                    file = _httpContext.Request.Form.Files.Count > 0 ? _httpContext.Request.Form.Files[0] : null;
+
                 if (file != null && file.Length == 0)
                 {
                     // create content for an empty file if necessary

--- a/src/Tests/SenseNet.ODataTest.WebApp/Startup.cs
+++ b/src/Tests/SenseNet.ODataTest.WebApp/Startup.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using SenseNet.Diagnostics;
 using SenseNet.OData;
 using SenseNet.Services.Core;
+using SenseNet.Services.Core.Virtualization;
 
 namespace SenseNet.ODataTest.WebApp
 {
@@ -50,6 +51,8 @@ namespace SenseNet.ODataTest.WebApp
             app.UseSenseNetAuthentication();
 
             app.UseMvc();
+
+            app.UseSenseNetFiles();
 
             app.UseSenseNetOdata();
         }


### PR DESCRIPTION
FIX: Use the missing "UseSenseNetFiles" in the ODataTest.WebApp.
FIX: Check FileText before access to Request.Form.