### PR TITLE
Parse uploaded ctd  and determine the correct parent.

### DIFF
--- a/src/Services.Core/Operations/UploadHandler.cs
+++ b/src/Services.Core/Operations/UploadHandler.cs
@@ -539,11 +539,6 @@ namespace SenseNet.Services.Core.Operations
             return UploadHelper.CreateBinaryData(fileName, setStream ? file?.OpenReadStream() : null, file?.ContentType);
         }
 
-        protected bool IsContentType()
-        {
-            return string.Equals(ContentTypeName, "ContentType", StringComparison.InvariantCultureIgnoreCase);
-        }
-
         private Content GetRealParent()
         {
             if (!string.Equals(ContentTypeName, "ContentType", StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
The solution was that in case of content types **the upload handler will determine the real parent based on the parsed CTD xml**. This was the most simple solution, because the content type installer API does not provide information about newly installed types and there is no CTD parse API that we could use.