### PR TITLE
Feature/configure registration

### DIFF
--- a/src/Services.Core/Authentication/AuthenticationExtensions.cs
+++ b/src/Services.Core/Authentication/AuthenticationExtensions.cs
@@ -1,16 +1,19 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using SenseNet.Services.Core.Authentication;
 
-namespace SenseNet.Services.Core.Authentication
+namespace SenseNet.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Custom service builder API for simplifying the addition of registration services.
+    /// </summary>
     public class SenseNetRegistrationBuilder
     {
-        internal AuthenticationBuilder AuthenticationBuilder { get; }
+        internal IServiceCollection Services { get; }
 
-        internal SenseNetRegistrationBuilder(AuthenticationBuilder builder) 
+        internal SenseNetRegistrationBuilder(IServiceCollection services) 
         {
-            AuthenticationBuilder = builder;
+            Services = services;
         }
     }
 
@@ -19,29 +22,19 @@ namespace SenseNet.Services.Core.Authentication
         /// <summary>
         /// Adds the sensenet registration feature to the service collection.
         /// </summary>
-        /// <param name="appBuilder">AuthenticationBuilder instance.</param>
-        /// <returns>A <see cref="SenseNetRegistrationBuilder"/> instance that lets developers
-        /// add custom features to the registration process.</returns>
-        public static SenseNetRegistrationBuilder AddSenseNetRegistration(this AuthenticationBuilder appBuilder)
-        {
-            return AddSenseNetRegistration(appBuilder, null);
-        }
-        /// <summary>
-        /// Adds the sensenet registration feature to the service collection.
-        /// </summary>
-        /// <param name="appBuilder">AuthenticationBuilder instance.</param>
+        /// <param name="services">The IServiceCollection instance.</param>
         /// <param name="configure">Optional configuration method.</param>
         /// <returns>A <see cref="SenseNetRegistrationBuilder"/> instance that lets developers
         /// add custom features to the registration process.</returns>
-        public static SenseNetRegistrationBuilder AddSenseNetRegistration(this AuthenticationBuilder appBuilder, 
-            Action<RegistrationOptions> configure)
+        public static SenseNetRegistrationBuilder AddSenseNetRegistration(this IServiceCollection services, 
+            Action<RegistrationOptions> configure = null)
         {
-            appBuilder.Services.Configure<RegistrationOptions>(options => { configure?.Invoke(options); });
-            appBuilder.Services.AddSingleton<DefaultRegistrationProvider>();
-            appBuilder.Services.AddSingleton<RegistrationProviderStore>();
+            services.Configure<RegistrationOptions>(options => { configure?.Invoke(options); });
+            services.AddSingleton<DefaultRegistrationProvider>();
+            services.AddSingleton<RegistrationProviderStore>();
 
             // return a feature-specific builder to simplify provider registration
-            return new SenseNetRegistrationBuilder(appBuilder);
+            return new SenseNetRegistrationBuilder(services);
         }
         /// <summary>
         /// Adds a custom registration provider singleton to the service collection.
@@ -52,7 +45,7 @@ namespace SenseNet.Services.Core.Authentication
         public static SenseNetRegistrationBuilder AddProvider<T>(this SenseNetRegistrationBuilder builder) where T : class, IRegistrationProvider
         {
             // The RegistrationProviderStore singleton will later resolve these instances when it is requested.
-            builder.AuthenticationBuilder.Services.AddSingleton<IRegistrationProvider, T>();
+            builder.Services.AddSingleton<IRegistrationProvider, T>();
 
             return builder;
         }

--- a/src/Services.Core/Authentication/DefaultRegistrationProvider.cs
+++ b/src/Services.Core/Authentication/DefaultRegistrationProvider.cs
@@ -24,7 +24,7 @@ namespace SenseNet.Services.Core.Authentication
     /// <remarks>
     /// Developers may inherit from this class and provide their own implementation
     /// using the helper methods of this built-in implementation.
-    /// Use the <see cref="AuthenticationExtensions.AddProvider"/> method during
+    /// Use the AddSenseNetRegistration and AddProvider methods during
     /// application start to register a custom instance for a particular 
     /// authentication provider (e.g. Google or Facebook).
     /// </remarks>

--- a/src/Services.Core/Authentication/IRegistrationProvider.cs
+++ b/src/Services.Core/Authentication/IRegistrationProvider.cs
@@ -23,6 +23,11 @@ namespace SenseNet.Services.Core.Authentication
     public interface IRegistrationProvider
     {
         /// <summary>
+        /// Defines the service handled by the provider.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Create users based on the auth provider that they used for signing in
         /// - e.g. Google or GitHub.
         /// </summary>

--- a/src/Services.Core/Authentication/RegistrationOptions.cs
+++ b/src/Services.Core/Authentication/RegistrationOptions.cs
@@ -12,5 +12,9 @@ namespace SenseNet.Services.Core.Authentication
         /// Content type of newly created users. Default: User.
         /// </summary>
         public string UserType { get; set; }
+        /// <summary>
+        /// Container of newly created users. Default: /Root/IMS/Public
+        /// </summary>
+        public string ParentPath { get; set; }
     }
 }

--- a/src/Services.Core/Authentication/RegistrationProviderStore.cs
+++ b/src/Services.Core/Authentication/RegistrationProviderStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SenseNet.Services.Core.Authentication
 {
@@ -10,30 +11,27 @@ namespace SenseNet.Services.Core.Authentication
     /// </summary>
     internal class RegistrationProviderStore
     {
-        private readonly IDictionary<string, IRegistrationProvider> Providers = new Dictionary<string, IRegistrationProvider>();
-        private readonly DefaultRegistrationProvider DefaultProvider = new DefaultRegistrationProvider();
+        private readonly IDictionary<string, IRegistrationProvider> _providers = new Dictionary<string, IRegistrationProvider>();
+        private readonly DefaultRegistrationProvider _defaultProvider;
 
-        public RegistrationProviderStore(RegistrationOptions options)
+        public RegistrationProviderStore(DefaultRegistrationProvider defaultProvider, IEnumerable<IRegistrationProvider> registeredProviders)
         {
-            DefaultProvider.DefaultGroups = options.Groups;
-            DefaultProvider.DefaultUserType = options.UserType;            
+            _defaultProvider = defaultProvider;
+
+            foreach (var provider in registeredProviders.Where(p => !string.IsNullOrEmpty(p?.Name)))
+            {
+                _providers[provider.Name] = provider;
+            }
         }
 
-        public void Add(string name, IRegistrationProvider provider)
-        {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException(nameof(name));
-
-            Providers[name] = provider ?? throw new ArgumentNullException(nameof(provider));
-        }
         public IRegistrationProvider Get(string name)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
 
-            return Providers.TryGetValue(name, out var provider)
+            return _providers.TryGetValue(name, out var provider)
                 ? provider
-                : DefaultProvider;
+                : _defaultProvider;
         }
     }
 }

--- a/src/Services.Core/ServicesExtensions.cs
+++ b/src/Services.Core/ServicesExtensions.cs
@@ -53,8 +53,10 @@ namespace SenseNet.Extensions.DependencyInjection
                 .AddSenseNetTaskManager()
                 .AddSenseNetDocumentPreviewProvider()
                 .AddSenseNetCors()
+                .AddSenseNetRegistration();
 
-                // add maintenance tasks
+            // add maintenance tasks
+            services
                 .AddSingleton<IMaintenanceTask, CleanupFilesTask>()
                 .AddSingleton<IMaintenanceTask, StartActiveDirectorySynchronizationTask>()
                 .AddSingleton<IMaintenanceTask, AccessTokenCleanupTask>()

--- a/src/Services.Core/ServicesExtensions.cs
+++ b/src/Services.Core/ServicesExtensions.cs
@@ -10,6 +10,7 @@ using SenseNet.ContentRepository.Storage;
 using SenseNet.ContentRepository.Storage.Security;
 using SenseNet.Diagnostics;
 using SenseNet.Services.Core;
+using SenseNet.Services.Core.Authentication;
 using SenseNet.Storage;
 using SenseNet.Storage.Security;
 using SenseNet.TaskManagement.Core;
@@ -30,6 +31,7 @@ namespace SenseNet.Extensions.DependencyInjection
         internal static IServiceCollection ConfigureSenseNet(this IServiceCollection services, IConfiguration configuration)
         {
             services.Configure<TaskManagementOptions>(configuration.GetSection("sensenet:TaskManagement"));
+            services.Configure<RegistrationOptions>(configuration.GetSection("sensenet:Registration"));
 
             return services;
         }

--- a/src/Tests/SenseNet.Services.Core.Tests/RegistrationTests.cs
+++ b/src/Tests/SenseNet.Services.Core.Tests/RegistrationTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SenseNet.ContentRepository;
+using SenseNet.Tests;
+using SenseNet.Services.Core.Authentication;
+using SenseNet.Services.Core.Operations;
+
+namespace SenseNet.Services.Core.Tests
+{
+    [TestClass]
+    public class RegistrationTests : TestBase
+    {
+        internal class TestRegistrationProvider1 : IRegistrationProvider
+        {
+            public string Name => "p1";
+            
+            public Task<User> CreateProviderUserAsync(Content content, HttpContext context, string provider, string userId, ClaimInfo[] claims,
+                CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<User> CreateLocalUserAsync(Content content, HttpContext context, string loginName, string password, string email,
+                CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+        internal class TestRegistrationProvider2 : IRegistrationProvider
+        {
+            public string Name => "p2";
+
+            public Task<User> CreateProviderUserAsync(Content content, HttpContext context, string provider, string userId, ClaimInfo[] claims,
+                CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task<User> CreateLocalUserAsync(Content content, HttpContext context, string loginName, string password, string email,
+                CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        [TestMethod]
+        public void Registration_AddProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            var builder = new AuthenticationBuilder(serviceCollection);
+
+            builder.AddSenseNetRegistration()
+                .AddProvider<TestRegistrationProvider1>()
+                .AddProvider<TestRegistrationProvider2>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var store = serviceProvider.GetRequiredService<RegistrationProviderStore>();
+
+            var p1 = store.Get("p1");
+            var p2 = store.Get("p2");
+            var pDefault = store.Get("p3");
+
+            Assert.AreEqual("p1", p1.Name);
+            Assert.AreEqual("p2", p2.Name);
+            Assert.AreEqual("default", pDefault.Name);
+        }
+    }
+}

--- a/src/Tests/SenseNet.Services.Core.Tests/RegistrationTests.cs
+++ b/src/Tests/SenseNet.Services.Core.Tests/RegistrationTests.cs
@@ -1,10 +1,10 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SenseNet.ContentRepository;
+using SenseNet.Extensions.DependencyInjection;
 using SenseNet.Tests;
 using SenseNet.Services.Core.Authentication;
 using SenseNet.Services.Core.Operations;
@@ -14,6 +14,7 @@ namespace SenseNet.Services.Core.Tests
     [TestClass]
     public class RegistrationTests : TestBase
     {
+        #region Test classes
         internal class TestRegistrationProvider1 : IRegistrationProvider
         {
             public string Name => "p1";
@@ -46,18 +47,18 @@ namespace SenseNet.Services.Core.Tests
                 throw new System.NotImplementedException();
             }
         }
+        #endregion
 
         [TestMethod]
         public void Registration_AddProvider()
         {
-            var serviceCollection = new ServiceCollection();
-            var builder = new AuthenticationBuilder(serviceCollection);
+            var services = new ServiceCollection();
 
-            builder.AddSenseNetRegistration()
+            services.AddSenseNetRegistration()
                 .AddProvider<TestRegistrationProvider1>()
                 .AddProvider<TestRegistrationProvider2>();
 
-            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var serviceProvider = services.BuildServiceProvider();
             var store = serviceProvider.GetRequiredService<RegistrationProviderStore>();
 
             var p1 = store.Get("p1");
@@ -67,6 +68,7 @@ namespace SenseNet.Services.Core.Tests
             Assert.AreEqual("p1", p1.Name);
             Assert.AreEqual("p2", p2.Name);
             Assert.AreEqual("default", pDefault.Name);
+            Assert.IsTrue(pDefault is DefaultRegistrationProvider);
         }
     }
 }

--- a/src/Tests/SenseNet.Services.Core.Tests/SenseNet.Services.Core.Tests.csproj
+++ b/src/Tests/SenseNet.Services.Core.Tests/SenseNet.Services.Core.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/src/WebApps/SnWebApplication.Api.InMem.Admin/Startup.cs
+++ b/src/WebApps/SnWebApplication.Api.InMem.Admin/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SenseNet.ContentRepository;
 using SenseNet.Extensions.DependencyInjection;
-using SenseNet.Services.Core.Authentication;
 
 namespace SnWebApplication.Api.InMem.Admin
 {
@@ -26,12 +25,13 @@ namespace SnWebApplication.Api.InMem.Admin
             services.AddRazorPages();
 
             // [sensenet]: Authentication: switched off below
-            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddSenseNetRegistration(options =>
-                {
-                    // add newly registered users to this group
-                    options.Groups.Add("/Root/IMS/Public/Administrators");
-                });
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme);
+            
+            services.AddSenseNetRegistration(options =>
+            {
+                // add newly registered users to this group
+                options.Groups.Add("/Root/IMS/Public/Administrators");
+            });
 
             // [sensenet]: add allowed client SPA urls
             services.AddSenseNetCors();

--- a/src/WebApps/SnWebApplication.Api.InMem.TokenAuth/Startup.cs
+++ b/src/WebApps/SnWebApplication.Api.InMem.TokenAuth/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SenseNet.Extensions.DependencyInjection;
-using SenseNet.Services.Core.Authentication;
 using SenseNet.Services.Core.Authentication.IdentityServer4;
 
 namespace SnWebApplication.Api.InMem.TokenAuth
@@ -38,8 +37,10 @@ namespace SnWebApplication.Api.InMem.TokenAuth
 
                     options.Audience = "sensenet";
                 })
-                .AddDefaultSenseNetIdentityServerClients(Configuration["sensenet:authentication:authority"])
-                .AddSenseNetRegistration();
+                .AddDefaultSenseNetIdentityServerClients(Configuration["sensenet:authentication:authority"]);
+
+            // [sensenet]: Registration
+            services.AddSenseNetRegistration();
 
             // [sensenet]: add allowed client SPA urls
             services.AddSenseNetCors();

--- a/src/WebApps/SnWebApplication.Api.Sql.Admin/Startup.cs
+++ b/src/WebApps/SnWebApplication.Api.Sql.Admin/Startup.cs
@@ -12,7 +12,6 @@ using SenseNet.Configuration;
 using SenseNet.ContentRepository;
 using SenseNet.Extensions.DependencyInjection;
 using SenseNet.Security.EFCSecurityStore;
-using SenseNet.Services.Core.Authentication;
 
 namespace SnWebApplication.Api.Sql.Admin
 {
@@ -33,12 +32,7 @@ namespace SnWebApplication.Api.Sql.Admin
             JwtSecurityTokenHandler.DefaultMapInboundClaims = false;
 
             // [sensenet]: Authentication: switched off below
-            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddSenseNetRegistration(options =>
-                {
-                    // add newly registered users to this group
-                    options.Groups.Add("/Root/IMS/Public/Administrators");
-                });
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme);
 
             // [sensenet]: add sensenet services
             services.AddSenseNet(Configuration, (repositoryBuilder, provider) =>

--- a/src/WebApps/SnWebApplication.Api.Sql.Admin/appsettings.json
+++ b/src/WebApps/SnWebApplication.Api.Sql.Admin/appsettings.json
@@ -15,6 +15,10 @@
       "Url": "",
       "ApplicationUrl": "",
       "ApplicationId": ""
+    },
+    "Registration": {
+      "Groups": [],
+      "UserType":  "" 
     }
   }
 }

--- a/src/WebApps/SnWebApplication.Api.Sql.TokenAuth/Startup.cs
+++ b/src/WebApps/SnWebApplication.Api.Sql.TokenAuth/Startup.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Hosting;
 using SenseNet.Configuration;
 using SenseNet.Extensions.DependencyInjection;
 using SenseNet.Security.EFCSecurityStore;
-using SenseNet.Services.Core.Authentication;
 using SenseNet.Services.Core.Authentication.IdentityServer4;
 
 namespace SnWebApplication.Api.Sql.TokenAuth
@@ -42,12 +41,7 @@ namespace SnWebApplication.Api.Sql.TokenAuth
 
                     options.Audience = "sensenet";
                 })
-                .AddDefaultSenseNetIdentityServerClients(Configuration["sensenet:authentication:authority"])
-                .AddSenseNetRegistration(options =>
-                {
-                    // add newly registered users to this group
-                    options.Groups.Add("/Root/IMS/Public/Administrators");
-                });
+                .AddDefaultSenseNetIdentityServerClients(Configuration["sensenet:authentication:authority"]);
 
             // [sensenet]: add sensenet services
             services.AddSenseNet(Configuration, (repositoryBuilder, provider) =>

--- a/src/WebApps/SnWebApplication.Api.Sql.TokenAuth/appsettings.json
+++ b/src/WebApps/SnWebApplication.Api.Sql.TokenAuth/appsettings.json
@@ -13,6 +13,10 @@
   "sensenet": {
     "authentication": {
       "authority": "https://localhost:44311"
+    },
+    "Registration": {
+      "Groups": [],
+      "UserType": ""
     }
   }
 }


### PR DESCRIPTION
This PR simplifies the registration of the user registration feature and moves it inside the main AddSenseNet method so that app developers do not have to add the feature manually: **it will be added automatically** with the main method above.

It is also possible to set the user creation values (parent, user type, groups) in **configuration**.