### PR TITLE
Add options for setting the http request's body size limit.

### DIFF
--- a/src/Services.Core/Configuration/HttpRequestOptions.cs
+++ b/src/Services.Core/Configuration/HttpRequestOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace SenseNet.Services.Core.Configuration
+{
+    public class HttpRequestOptions
+    {
+        public long MaxRequestBodySize { get; set; }
+    }
+}

--- a/src/Services.Core/ServicesExtensions.cs
+++ b/src/Services.Core/ServicesExtensions.cs
@@ -12,6 +12,7 @@ using SenseNet.Diagnostics;
 using SenseNet.Services.Core;
 using SenseNet.Services.Core.Authentication;
 using SenseNet.Services.Core.Authentication.IdentityServer4;
+using SenseNet.Services.Core.Configuration;
 using SenseNet.Storage;
 using SenseNet.Storage.Security;
 using SenseNet.TaskManagement.Core;
@@ -36,6 +37,7 @@ namespace SenseNet.Extensions.DependencyInjection
             services.Configure<RegistrationOptions>(configuration.GetSection("sensenet:Registration"));
             services.Configure<AuthenticationOptions>(configuration.GetSection("sensenet:Authentication"));
             services.Configure<ClientRequestOptions>(configuration.GetSection("sensenet:ClientRequest"));
+            services.Configure<HttpRequestOptions>(configuration.GetSection("sensenet:HttpRequest"));
             
             return services;
         }

--- a/src/Tests/SenseNet.ODataTests/ODataGeneralTests.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataGeneralTests.cs
@@ -35,7 +35,7 @@ namespace SenseNet.ODataTests
                 httpContext.Response.Body = new MemoryStream();
 
                 // ACTION
-                var odata = new ODataMiddleware(null, null);
+                var odata = new ODataMiddleware(null, null, null);
                 await odata.ProcessRequestAsync(httpContext, null).ConfigureAwait(false);
 
                 // ASSERT

--- a/src/Tests/SenseNet.ODataTests/ODataMiddlewareTests.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataMiddlewareTests.cs
@@ -43,7 +43,7 @@ namespace SenseNet.ODataTests
 
                 // ACTION: Simulate the aspnet framework
                 // instantiate the OData with the next chain member
-                var odata = new ODataMiddleware(new TestMiddleware(null).InvokeAsync, null);
+                var odata = new ODataMiddleware(new TestMiddleware(null).InvokeAsync, null, null);
                 // call the first of the chain
                 await odata.InvokeAsync(httpContext);
 
@@ -76,7 +76,7 @@ namespace SenseNet.ODataTests
                 var responseStream = httpContext.Response.Body = new MemoryStream();
 
                 // ACTION: Simulate the aspnet framework
-                var odata = new ODataMiddleware(null, null);
+                var odata = new ODataMiddleware(null, null, null);
                 // call the first of the chain
                 await odata.InvokeAsync(httpContext);
 

--- a/src/Tests/SenseNet.ODataTests/ODataOperationMethodTests.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataOperationMethodTests.cs
@@ -2949,7 +2949,7 @@ namespace SenseNet.ODataTests
         {
             public CleanOperationCenterBlock()
             {
-                var _ = new ODataMiddleware(null, null); // Ensure running the first-touch discover
+                var _ = new ODataMiddleware(null, null, null); // Ensure running the first-touch discover
                 OperationCenter.Operations.Clear();
             }
             public void Dispose()

--- a/src/Tests/SenseNet.ODataTests/ODataTestBase.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataTestBase.cs
@@ -437,7 +437,7 @@ namespace SenseNet.ODataTests
 
             httpContext.Response.Body = new MemoryStream();
 
-            var odata = new ODataMiddleware(null, config);
+            var odata = new ODataMiddleware(null, config, null);
             var odataRequest = ODataRequest.Parse(httpContext);
             await odata.ProcessRequestAsync(httpContext, odataRequest).ConfigureAwait(false);
 


### PR DESCRIPTION
Currently we use this configuration only in the OData middleware.