### PR TITLE
Reset client schema cache when string resource manager is restarted.

### DIFF
--- a/src/ContentRepository/i18n/SenseNetResourceManager.cs
+++ b/src/ContentRepository/i18n/SenseNetResourceManager.cs
@@ -76,6 +76,8 @@ namespace SenseNet.ContentRepository.i18n
             {
                 _current = null;
             }
+
+            ResourceManagerRestarted?.Invoke(null, EventArgs.Empty);
         }
 
         // ================================================================ Static part
@@ -114,6 +116,11 @@ namespace SenseNet.ContentRepository.i18n
 
         [Obsolete("After V6.5 PATCH 9: Use RepositoryEnvironment.FallbackCulture instead.")]
         public static string FallbackCulture => RepositoryEnvironment.FallbackCulture;
+
+        /// <summary>
+        /// Defines an event that occurs when the resource manager is restarted.
+        /// </summary>
+        public static event EventHandler ResourceManagerRestarted;
 
         public static bool Running
         {

--- a/src/OData/Metadata/ClientMetadataProvider.cs
+++ b/src/OData/Metadata/ClientMetadataProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using SenseNet.ContentRepository.i18n;
 using SenseNet.Diagnostics;
 using SenseNet.OData.Typescript;
 
@@ -59,10 +60,12 @@ namespace SenseNet.OData.Metadata
         {
             // per-instance event subscription
             ContentType.TypeSystemRestarted += OnTypeSystemRestarted;
+            SenseNetResourceManager.ResourceManagerRestarted += OnResourceManagerRestarted;
         }
         ~ClientMetadataProvider()
         {
             ContentType.TypeSystemRestarted -= OnTypeSystemRestarted;
+            SenseNetResourceManager.ResourceManagerRestarted -= OnResourceManagerRestarted;
         }
 
         //======================================================================================= Event handlers
@@ -71,6 +74,18 @@ namespace SenseNet.OData.Metadata
         /// Instance-level event handler that is called when the content type system restarts.
         /// </summary>
         protected virtual void OnTypeSystemRestarted(object o, EventArgs eventArgs)
+        {
+            Reset();
+        }
+        /// <summary>
+        /// Instance-level event handler that is called when the resource manager restarts.
+        /// </summary>
+        protected virtual void OnResourceManagerRestarted(object o, EventArgs eventArgs)
+        {
+            Reset();
+        }
+
+        internal void Reset()
         {
             _contentTypes.Clear();
             SnTrace.Repository.Write("ClientMetadataProvider Reset");


### PR DESCRIPTION
A new reset event was added to String resource manager to let features in upper layers perform operations when the resource manager is restarted.