### PR TITLE
Add Save and Delete permissions for the Owners group on Localization.

### DIFF
--- a/src/nuget/snadmin/install-services/import/Localization.Content
+++ b/src/nuget/snadmin/install-services/import/Localization.Content
@@ -7,6 +7,10 @@
   </Fields>
   <Permissions>
     <Clear />
+    <Identity path="/Root/IMS/BuiltIn/Portal/Owners">
+      <Save>Allow</Save>
+      <Delete>Allow</Delete>
+    </Identity>
     <Identity path="/Root/IMS/BuiltIn/Portal/Developers">
       <See>Allowed</See>
       <Preview>Allowed</Preview>


### PR DESCRIPTION
This will allow users to delete or modify the resources they created - but not built-in resources or the ones created by others.