### PR TITLE
Doclib allowed childtypes

### DIFF
--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/DocumentLibraryCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/DocumentLibraryCtd.xml
@@ -4,7 +4,7 @@
   <Description>$Ctd-DocumentLibrary,Description</Description>
   <Icon>ContentList</Icon>
   <AllowedChildTypes>
-    Folder,File
+    Folder,File,Image
   </AllowedChildTypes>
   <Fields>
   <Field name="DisplayName" type="ShortText">


### PR DESCRIPTION
Add Image as allowed type to the doclib ctd to handle copying/moving previews along with the files