### PR TITLE
Fix/patching

### DIFF
--- a/src/ContentRepository/Packaging/PatchExecutionContext.cs
+++ b/src/ContentRepository/Packaging/PatchExecutionContext.cs
@@ -9,13 +9,13 @@ namespace SenseNet.Packaging
     {
         public RepositoryStartSettings Settings { get; }
         public List<PatchExecutionError> Errors { get; } = new List<PatchExecutionError>();
-        public Action<PatchExecutionLogRecord> LogCallback { get; } = DefaultLogCallback;
+        public Action<PatchExecutionLogRecord> LogCallback { get; }
         public ISnPatch CurrentPatch { get; internal set; }
 
         public PatchExecutionContext(RepositoryStartSettings settings, Action<PatchExecutionLogRecord> logCallback)
         {
             Settings = settings;
-            LogCallback = logCallback;
+            LogCallback = logCallback ?? DefaultLogCallback;
         }
 
         private static void DefaultLogCallback(PatchExecutionLogRecord msg)

--- a/src/ContentRepository/Packaging/PatchExecutionContext.cs
+++ b/src/ContentRepository/Packaging/PatchExecutionContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using SenseNet.ContentRepository;
 
 // ReSharper disable once CheckNamespace
@@ -7,7 +8,7 @@ namespace SenseNet.Packaging
     public class PatchExecutionContext
     {
         public RepositoryStartSettings Settings { get; }
-        public PatchExecutionError[] Errors { get; internal set; } = new PatchExecutionError[0];
+        public List<PatchExecutionError> Errors { get; } = new List<PatchExecutionError>();
         public Action<PatchExecutionLogRecord> LogCallback { get; } = DefaultLogCallback;
         public ISnPatch CurrentPatch { get; internal set; }
 

--- a/src/ContentRepository/Packaging/PatchExecutionError.cs
+++ b/src/ContentRepository/Packaging/PatchExecutionError.cs
@@ -1,12 +1,14 @@
-﻿using System.Linq;
+﻿using System.Diagnostics;
+using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace SenseNet.Packaging
 {
     public enum PatchExecutionErrorType
     {
-        DuplicatedInstaller, CannotInstall, MissingVersion
+        DuplicatedInstaller, CannotInstall, MissingVersion, ErrorInExecution
     }
+    [DebuggerDisplay("{ToString()())}")]
     public class PatchExecutionError
     {
         public PatchExecutionErrorType ErrorType { get; }
@@ -27,6 +29,11 @@ namespace SenseNet.Packaging
             FaultyPatches = faultyPatches;
             FaultyPatch = faultyPatches?.FirstOrDefault();
             Message = message;
+        }
+
+        public override string ToString()
+        {
+            return $"{ErrorType} {FaultyPatch}";
         }
     }
 }

--- a/src/ContentRepository/Packaging/PatchExecutionLogRecord.cs
+++ b/src/ContentRepository/Packaging/PatchExecutionLogRecord.cs
@@ -5,7 +5,9 @@ namespace SenseNet.Packaging
 {
     public enum PatchExecutionEventType
     {
-        ExecutionStart, ExecutionFinished, PackageNotSaved
+        ExecutionStart, ExecutionFinished, ExecutionError, PackageNotSaved,
+        CannotExecute, CannotExecuteMissingVersion,
+        DuplicatedInstaller
     }
     [DebuggerDisplay("{ToString()}")]
     public struct PatchExecutionLogRecord

--- a/src/ContentRepository/Packaging/PatchManager.cs
+++ b/src/ContentRepository/Packaging/PatchManager.cs
@@ -130,13 +130,30 @@ namespace SenseNet.Packaging
 
         public void ExecuteRelevantPatches(IEnumerable<ISnPatch> candidates, PatchExecutionContext context)
         {
-            ExecuteRelevantPatches(candidates, LoadInstalledComponents(), context);
+            var patchesToExec = candidates.ToList();
+            while (true)
+            {
+                var installedComponents = LoadInstalledComponents();
+                var executables = GetExecutablePatches(patchesToExec, installedComponents, context, out _);
+                if (executables.Length == 0)
+                    break;
+
+                var faulty = ExecutePatches(executables, context);
+
+                if (faulty == null)
+                    break;
+                patchesToExec.Remove(faulty);
+                if (patchesToExec.Count == 0)
+                    break;
+            }
+
         }
 
-        public void ExecuteRelevantPatches(IEnumerable<ISnPatch> candidates,
+        internal ISnPatch ExecuteRelevantPatches(IEnumerable<ISnPatch> candidates, 
             SnComponentDescriptor[] installedComponents, PatchExecutionContext context)
         {
-            ExecutePatches(GetExecutablePatches(candidates, installedComponents, context, out _), context);
+            return ExecutePatches(
+                GetExecutablePatches(candidates, installedComponents, context, out _), context);
         }
 
         public IEnumerable<ISnPatch> GetExecutablePatches(IEnumerable<ISnPatch> candidates, PatchExecutionContext context)
@@ -151,7 +168,7 @@ namespace SenseNet.Packaging
                 .Select(x => new SnComponentDescriptor(x)).ToArray() ?? Array.Empty<SnComponentDescriptor>();
         }
 
-        public IEnumerable<ISnPatch> GetExecutablePatches(IEnumerable<ISnPatch> candidates,
+        public ISnPatch[] GetExecutablePatches(IEnumerable<ISnPatch> candidates,
             SnComponentDescriptor[] installedComponents, PatchExecutionContext context, out SnComponentDescriptor[] componentsAfter)
         {
             var patches = candidates.ToArray();
@@ -170,11 +187,11 @@ namespace SenseNet.Packaging
             if (duplicates.Length > 0)
             {
                 // Duplicates are not allowed
-                context.Errors = duplicates
+                context.Errors.AddRange(duplicates
                     .Select(id => new PatchExecutionError(PatchExecutionErrorType.DuplicatedInstaller,
                         installers.Where(inst => inst.ComponentId == id).ToArray(),
                         "There is a duplicated installer for the component " + id))
-                    .ToArray();
+                    .ToArray());
 
                 // Set unchanged list as output
                 componentsAfter = installedComponents.ToArray();
@@ -196,13 +213,11 @@ namespace SenseNet.Packaging
             {
                 foreach (var item in inputList)
                 {
-                    if (CheckPrerequisites(item, installed, out var skipExecution))
+                    if (CheckPrerequisites(item, installed, out var skipExecution, out var error))
                     {
                         currentlyManaged.Add(item);
                         outputList.Add(item);
 
-                        // The check SnPatch needs to precede the ComponentInstaller
-                        // because the SnPatch IS A ComponentInstaller
                         if (item is SnPatch snPatch)
                         {
                             // Modify version and dependencies of the installed components.
@@ -244,21 +259,22 @@ namespace SenseNet.Packaging
             // If exited but there is any remaining item, generate error(s).
             if (inputList.Count > 0)
             {
-                context.Errors = inputList
-                    .Select(patch => RecognizeDiscoveryProblem(patch, installedComponents))
-                    .ToArray();
+                context.Errors.AddRange(inputList
+                    //.Select(patch => RecognizeDiscoveryProblem(patch, installedComponents))
+                    .Select(patch => RecognizeDiscoveryProblem(patch, installed))
+                    .ToArray());
 
-                // Any installation is skipped.
-                componentsAfter = installedComponents.ToArray();
-                return new ISnPatch[0];
+                //// Any installation is skipped.
+                //componentsAfter = installedComponents.ToArray();
+                //return new ISnPatch[0];
             }
 
             componentsAfter = installed.ToArray();
 
-            return outputList;
+            return outputList.ToArray();
         }
 
-        private PatchExecutionError RecognizeDiscoveryProblem(ISnPatch patch, SnComponentDescriptor[] installedComponents)
+        private PatchExecutionError RecognizeDiscoveryProblem(ISnPatch patch, List<SnComponentDescriptor> installedComponents)
         {
             if (patch is SnPatch snPatch)
             {
@@ -276,21 +292,22 @@ namespace SenseNet.Packaging
         /// <summary>
         /// Returns true if the given <see cref="ISnPatch"/> is installable.
         /// </summary>
-        private bool CheckPrerequisites(ISnPatch patch, List<SnComponentDescriptor> installed, out bool skipExecution)
+        private bool CheckPrerequisites(ISnPatch patch, List<SnComponentDescriptor> installed, out bool skipExecution, out PatchExecutionError error)
         {
             if (patch is SnPatch snPatch)
-                return CheckPrerequisites(snPatch, installed, out skipExecution);
+                return CheckPrerequisites(snPatch, installed, out skipExecution, out error);
             if (patch is ComponentInstaller installer)
-                return CheckPrerequisites(installer, installed, out skipExecution);
+                return CheckPrerequisites(installer, installed, out skipExecution, out error);
             throw new SnNotSupportedException();
         }
         /// <summary>
         /// Returns true if the given <see cref="ComponentInstaller"/> is installable.
         /// </summary>
         private bool CheckPrerequisites(ComponentInstaller installer, List<SnComponentDescriptor> installed,
-            out bool skipExecution)
+            out bool skipExecution, out PatchExecutionError error)
         {
             skipExecution = false;
+            error = null;
             // Installable if the dependent components exist.
             return CheckDependencies(installer, installed);
         }
@@ -298,9 +315,10 @@ namespace SenseNet.Packaging
         /// Returns true if the given <see cref="SnPatch"/> is installable.
         /// </summary>
         private bool CheckPrerequisites(SnPatch snPatch, List<SnComponentDescriptor> installed,
-            out bool skipExecution)
+            out bool skipExecution, out PatchExecutionError error)
         {
             skipExecution = false;
+            error = null;
 
             // Search the installed component.
             var target = installed.FirstOrDefault(x => x.ComponentId == snPatch.ComponentId);
@@ -345,7 +363,7 @@ namespace SenseNet.Packaging
                 installed.Any(i => i.ComponentId == dep.Id && dep.Boundary.IsInInterval(i.Version)));
         }
 
-        private void ExecutePatches(IEnumerable<ISnPatch> patches, PatchExecutionContext context)
+        private ISnPatch ExecutePatches(IEnumerable<ISnPatch> patches, PatchExecutionContext context)
         {
             try
             {
@@ -377,6 +395,7 @@ namespace SenseNet.Packaging
                     catch (Exception e)
                     {
                         executionError = e;
+                        context.Errors.Add(new PatchExecutionError(PatchExecutionErrorType.ErrorInExecution, patch, e.Message));
                     }
 
                     try
@@ -394,12 +413,19 @@ namespace SenseNet.Packaging
                             patch));
                         throw new PackagingException("Cannot save the package.", e);
                     }
+
+                    // Return the current patch in case of faulty execution.
+                    if(executionError != null)
+                        return patch;
                 }
             }
             finally
             {
-                RepositoryVersionInfo.Reset();
+                RepositoryVersionInfo.Reset();//UNDONE:PATCH: Determine final place of the RepositoryVersionInfo.Reset()
             }
+
+            // There is no faulty patch.
+            return null;
         }
 
         /* ================================================================================= EXPERIMENTAL */

--- a/src/ContentRepository/Packaging/PatchManager.cs
+++ b/src/ContentRepository/Packaging/PatchManager.cs
@@ -142,11 +142,19 @@ namespace SenseNet.Packaging
 
                 if (faulty == null)
                     break;
-                patchesToExec.Remove(faulty);
+
+                RemoveNotExecutables(context, patchesToExec);
                 if (patchesToExec.Count == 0)
                     break;
             }
 
+        }
+
+        private void RemoveNotExecutables(PatchExecutionContext context, List<ISnPatch> patchesToExec)
+        {
+            var patches = context.Errors.SelectMany(x => x.FaultyPatches);
+            foreach (var patch in patches)
+                patchesToExec.Remove(patch);
         }
 
         internal ISnPatch ExecuteRelevantPatches(IEnumerable<ISnPatch> candidates, 
@@ -260,13 +268,8 @@ namespace SenseNet.Packaging
             if (inputList.Count > 0)
             {
                 context.Errors.AddRange(inputList
-                    //.Select(patch => RecognizeDiscoveryProblem(patch, installedComponents))
                     .Select(patch => RecognizeDiscoveryProblem(patch, installed))
                     .ToArray());
-
-                //// Any installation is skipped.
-                //componentsAfter = installedComponents.ToArray();
-                //return new ISnPatch[0];
             }
 
             componentsAfter = installed.ToArray();

--- a/src/Tests/SenseNet.Packaging.Tests/PatchingExecutionTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PatchingExecutionTests.cs
@@ -515,11 +515,13 @@ namespace SenseNet.Packaging.Tests
 
             // ASSERT
             Assert.AreEqual("ErrorInExecution C1: 1.0", ErrorsToString(context));
-            Assert.AreEqual(2, log.Count);
+            Assert.AreEqual(3, log.Count);
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
-            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
+            Assert.AreEqual("[C1: 1.0] ExecutionError. Err", log[1].ToString());
+            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[2].ToString());
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
-            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[1]));
+            Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[1]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[2]));
         }
         [TestMethod]
         public void PatchingExec_PatchOne_Success()
@@ -589,17 +591,19 @@ namespace SenseNet.Packaging.Tests
 
             // ASSERT
             Assert.AreEqual("ErrorInExecution C1: 1.0 <= v < 2.0 --> 2.0", ErrorsToString(context));
-            Assert.AreEqual(4, log.Count);
+            Assert.AreEqual(5, log.Count);
             Assert.AreEqual("C1i1.0", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
             Assert.AreEqual("[C1: 1.0] ExecutionFinished. Successful", log[1].ToString());
             Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[2].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[3].ToString());
-            Assert.AreEqual(4, packages.Count);
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionError. Err", log[3].ToString());
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[4].ToString());
+            Assert.AreEqual(5, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
             Assert.AreEqual("1, C1: Install Successful, 1.0", PackagesToString(packages[1]));
             Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[2]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[4]));
         }
         [TestMethod]
         public void PatchingExec_SkipPatch_FaultyInstaller()
@@ -630,13 +634,17 @@ namespace SenseNet.Packaging.Tests
             // ASSERT
             Assert.AreEqual("ErrorInExecution C1: 1.0, MissingVersion C1: 1.0 <= v < 2.0 --> 2.0",
                 ErrorsToString(context));
-            Assert.AreEqual(2, log.Count);
+            Assert.AreEqual(4, log.Count);
             Assert.AreEqual("", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
-            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
-            Assert.AreEqual(2, packages.Count);
+            Assert.AreEqual("[C1: 1.0] ExecutionError. Err", log[1].ToString());
+            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[2].ToString());
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] CannotExecuteMissingVersion.", log[3].ToString());
+            Assert.AreEqual(4, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
-            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[1]));
+            Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[1]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[2]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[3]));
         }
         [TestMethod]
         public void PatchingExec_SkipPatch_FaultySnPatch()
@@ -670,14 +678,20 @@ namespace SenseNet.Packaging.Tests
                             "MissingVersion C1: 2.0 <= v < 3.0 --> 3.0",
                 string.Join(", ", context.Errors.Select(x=>x.ToString())));
             Assert.AreEqual("C1i1.0", PatchesToString(executed.ToArray()));
-            Assert.AreEqual(4, log.Count);
+            Assert.AreEqual(6, log.Count);
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
             Assert.AreEqual("[C1: 1.0] ExecutionFinished. Successful", log[1].ToString());
-            Assert.AreEqual(4, packages.Count);
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[2].ToString());
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionError. Err", log[3].ToString());
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[4].ToString());
+            Assert.AreEqual("[C1: 2.0 <= v < 3.0 --> 3.0] CannotExecuteMissingVersion.", log[5].ToString());
+            Assert.AreEqual(6, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
             Assert.AreEqual("1, C1: Install Successful, 1.0", PackagesToString(packages[1]));
             Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[2]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[4]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[5]));
         }
 
         [TestMethod]
@@ -726,32 +740,37 @@ namespace SenseNet.Packaging.Tests
                 ErrorsToString(context));
 
             Assert.AreEqual("C2i1.0 C3i1.0 C3p2.0 C3p3.0", PatchesToString(executed.ToArray()));
-            Assert.AreEqual(12, log.Count);
+            Assert.AreEqual(17, log.Count);
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
-            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
-            Assert.AreEqual("[C2: 1.0] ExecutionStart.", log[2].ToString());
-            Assert.AreEqual("[C2: 1.0] ExecutionFinished. Successful", log[3].ToString());
-            Assert.AreEqual("[C3: 1.0] ExecutionStart.", log[4].ToString());
-            Assert.AreEqual("[C3: 1.0] ExecutionFinished. Successful", log[5].ToString());
-            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[6].ToString());
-            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[7].ToString());
-            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[8].ToString());
-            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[9].ToString());
-            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionStart.", log[10].ToString());
-            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionFinished. Successful", log[11].ToString());
-            Assert.AreEqual(12, packages.Count);
+            Assert.AreEqual("[C1: 1.0] ExecutionError. Err", log[1].ToString());
+            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[2].ToString());
+            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] CannotExecuteMissingVersion.", log[3].ToString());
+            Assert.AreEqual("[C1: 2.0 <= v < 3.0 --> 3.0] CannotExecuteMissingVersion.", log[4].ToString());
+            Assert.AreEqual("[C2: 1.0] ExecutionStart.", log[5].ToString());
+            Assert.AreEqual("[C2: 1.0] ExecutionFinished. Successful", log[6].ToString());
+            Assert.AreEqual("[C3: 1.0] ExecutionStart.", log[7].ToString());
+            Assert.AreEqual("[C3: 1.0] ExecutionFinished. Successful", log[8].ToString());
+            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[9].ToString());
+            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionError. Err", log[10].ToString());
+            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[11].ToString());
+            Assert.AreEqual("[C2: 2.0 <= v < 3.0 --> 3.0] CannotExecuteMissingVersion.", log[12].ToString());
+            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[13].ToString());
+            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[14].ToString());
+            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionStart.", log[15].ToString());
+            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionFinished. Successful", log[16].ToString());
+            Assert.AreEqual(17, packages.Count);
             Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
                             "2, C2: Install Successful, 1.0|" +
                             "3, C3: Install Successful, 1.0|" +
                             "4, C2: Patch Faulty, 2.0|" +
                             "5, C3: Patch Successful, 2.0|" +
-                            "6, C3: Patch Unfinished, 3.0", PackagesToString(packages[10]));
+                            "6, C3: Patch Unfinished, 3.0", PackagesToString(packages[15]));
             Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
                             "2, C2: Install Successful, 1.0|" +
                             "3, C3: Install Successful, 1.0|" +
                             "4, C2: Patch Faulty, 2.0|" +
                             "5, C3: Patch Successful, 2.0|" +
-                            "6, C3: Patch Successful, 3.0", PackagesToString(packages[11]));
+                            "6, C3: Patch Successful, 3.0", PackagesToString(packages[16]));
         }
 
         /* ======================================================== Tools */

--- a/src/Tests/SenseNet.Packaging.Tests/PatchingExecutionTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PatchingExecutionTests.cs
@@ -88,7 +88,7 @@ namespace SenseNet.Packaging.Tests
             Assert.AreEqual(1, after.Length);
             Assert.AreEqual(0, executables.Length);
             var errors = context.Errors;
-            Assert.AreEqual(2, errors.Length);
+            Assert.AreEqual(2, errors.Count);
             Assert.IsTrue(errors[0].Message.Contains("C3"));
             Assert.AreEqual(PatchExecutionErrorType.DuplicatedInstaller, errors[0].ErrorType);
             Assert.AreEqual(2, errors[0].FaultyPatches.Length);
@@ -171,7 +171,7 @@ namespace SenseNet.Packaging.Tests
             Assert.AreEqual("C1", string.Join(",", after.Select(x => x.ComponentId)));
             Assert.AreEqual(0, executables.Length);
             // Circular dependency causes error but the reason is not recognized yet.
-            Assert.AreEqual(3, context.Errors.Length);
+            Assert.AreEqual(3, context.Errors.Count);
             Assert.AreEqual(PatchExecutionErrorType.CannotInstall, context.Errors[0].ErrorType);
             Assert.AreEqual(PatchExecutionErrorType.CannotInstall, context.Errors[1].ErrorType);
             Assert.AreEqual(PatchExecutionErrorType.CannotInstall, context.Errors[2].ErrorType);
@@ -217,7 +217,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v3.0", ComponentsToString(after));
             Assert.AreEqual("C1i1.0 C1p2.0 C1p3.0", PatchesToString(executables));
         }
@@ -241,7 +241,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v3.0", ComponentsToString(after));
             Assert.AreEqual("C1p2.0 C1p3.0", PatchesToString(executables));
         }
@@ -265,7 +265,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v3.0", ComponentsToString(after));
             Assert.AreEqual("C1p3.0", PatchesToString(executables));
         }
@@ -289,7 +289,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v3.0", ComponentsToString(after));
             Assert.AreEqual("", PatchesToString(executables));
         }
@@ -311,11 +311,12 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(1, context.Errors.Length);
+            Assert.AreEqual("CannotInstall C2: 1.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             Assert.AreEqual(PatchExecutionErrorType.CannotInstall, context.Errors[0].ErrorType);
             Assert.AreEqual(patches[0], context.Errors[0].FaultyPatch);
-            Assert.AreEqual(0, after.Length);
-            Assert.AreEqual(0, executables.Length);
+            Assert.AreEqual("C1v1.0", ComponentsToString(after));
+            Assert.AreEqual("C1i1.0", PatchesToString(executables));
         }
         [TestMethod]
         public void PatchingExecSim_Patch_C2toC1v2_b()
@@ -334,7 +335,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v2.0 C2v1.0", ComponentsToString(after));
             Assert.AreEqual("C1i1.0 C1p2.0 C2i1.0", PatchesToString(executables));
         }
@@ -358,7 +359,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v2.0 C2v2.0", ComponentsToString(after));
             Assert.AreEqual("C1i1.0 C2i1.0 C2p2.0 C1p2.0", PatchesToString(executables));
         }
@@ -381,12 +382,13 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(1, context.Errors.Length);
+            Assert.AreEqual("MissingVersion C1: 3.0 <= v < 4.0 --> 4.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             var error = context.Errors[0];
             Assert.AreEqual(PatchExecutionErrorType.MissingVersion, error.ErrorType);
             Assert.AreEqual("C1: 3.0 <= v < 4.0 --> 4.0", error.FaultyPatch.ToString());
-            Assert.AreEqual("", ComponentsToString(after));
-            Assert.AreEqual("", PatchesToString(executables));
+            Assert.AreEqual("C1v2.0", ComponentsToString(after));
+            Assert.AreEqual("C1i1.0 C1p2.0", PatchesToString(executables));
         }
         [TestMethod]
         public void PatchingExecSim_Patch_MissingItemInTheChain_b()
@@ -408,12 +410,13 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(1, context.Errors.Length);
+            Assert.AreEqual("MissingVersion C1: 3.0 <= v < 4.0 --> 4.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             var error = context.Errors[0];
             Assert.AreEqual(PatchExecutionErrorType.MissingVersion, error.ErrorType);
             Assert.AreEqual("C1: 3.0 <= v < 4.0 --> 4.0", error.FaultyPatch.ToString());
             Assert.AreEqual("C1v2.0", ComponentsToString(after));
-            Assert.AreEqual("", PatchesToString(executables));
+            Assert.AreEqual("C1p2.0", PatchesToString(executables));
         }
         [TestMethod]
         public void PatchingExecSim_Patch_MissingItemInTheChain_c()
@@ -435,7 +438,8 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(1, context.Errors.Length);
+            Assert.AreEqual("MissingVersion C1: 3.0 <= v < 4.0 --> 4.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             var error = context.Errors[0];
             Assert.AreEqual(PatchExecutionErrorType.MissingVersion, error.ErrorType);
             Assert.AreEqual("C1: 3.0 <= v < 4.0 --> 4.0", error.FaultyPatch.ToString());
@@ -462,7 +466,7 @@ namespace SenseNet.Packaging.Tests
             var executables = pm.GetExecutablePatches(patches, installed, context, out var after).ToArray();
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual("C1v4.0", ComponentsToString(after));
             Assert.AreEqual("C1p4.0", PatchesToString(executables));
         }
@@ -501,7 +505,7 @@ namespace SenseNet.Packaging.Tests
             pm.ExecuteRelevantPatches(patches, installed, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual(2, log.Count);
             Assert.AreEqual("C1i1.0", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
@@ -530,10 +534,7 @@ namespace SenseNet.Packaging.Tests
             var installed = new SnComponentDescriptor[0];
             var patches = new ISnPatch[]
             {
-                //Patch("C1", "1.0 <= v < 2.0", "v2.0", null, 
-                //    ctx => ExecutionResult.Successful),
-                Inst("C1", "v1.0", null,
-                    ctx => { throw new Exception("Error inda patch."); }),
+                Inst("C1", "v1.0", null, context => { throw new Exception("Err"); }),
             };
 
             // ACTION
@@ -542,7 +543,8 @@ namespace SenseNet.Packaging.Tests
             pm.ExecuteRelevantPatches(patches, installed, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual("ErrorInExecution C1: 1.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             Assert.AreEqual(2, log.Count);
             Assert.AreEqual("", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
@@ -582,7 +584,7 @@ namespace SenseNet.Packaging.Tests
             pm.ExecuteRelevantPatches(patches, installed, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual(4, log.Count);
             Assert.AreEqual("C1i1.0 C1p2.0", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
@@ -627,7 +629,8 @@ namespace SenseNet.Packaging.Tests
             pm.ExecuteRelevantPatches(patches, installed, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual("ErrorInExecution C1: 1.0 <= v < 2.0 --> 2.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             Assert.AreEqual(4, log.Count);
             Assert.AreEqual("C1i1.0", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
@@ -658,7 +661,6 @@ namespace SenseNet.Packaging.Tests
                 executed.Add(patch);
             }
 
-            var installed = new SnComponentDescriptor[0];
             var patches = new ISnPatch[]
             {
                 Patch("C1", "1.0 <= v < 2.0", "v2.0", ctx => { Execute(ctx.CurrentPatch); }),
@@ -668,21 +670,18 @@ namespace SenseNet.Packaging.Tests
             // ACTION
             var context = new PatchExecutionContext(null, LogMessage);
             var pm = new PatchManager(context);
-            pm.ExecuteRelevantPatches(patches, installed, context);
+            pm.ExecuteRelevantPatches(patches, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
+            Assert.AreEqual("ErrorInExecution C1: 1.0, MissingVersion C1: 1.0 <= v < 2.0 --> 2.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
             Assert.AreEqual(2, log.Count);
             Assert.AreEqual("", PatchesToString(executed.ToArray()));
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
             Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[2].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[3].ToString());
-            Assert.AreEqual(4, packages.Count);
+            Assert.AreEqual(2, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0", PackagesToString(packages[1]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[2]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Successful, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[1]));
         }
         [TestMethod]
         public void PatchingExec_SkipPatch_FaultySnPatch()
@@ -702,7 +701,6 @@ namespace SenseNet.Packaging.Tests
                 executed.Add(patch);
             }
 
-            var installed = new SnComponentDescriptor[0];
             var patches = new ISnPatch[]
             {
                 Patch("C1", "2.0 <= v < 3.0", "v3.0", ctx => { Execute(ctx.CurrentPatch); }),
@@ -713,22 +711,23 @@ namespace SenseNet.Packaging.Tests
             // ACTION
             var context = new PatchExecutionContext(null, LogMessage);
             var pm = new PatchManager(context);
-            pm.ExecuteRelevantPatches(patches, installed, context);
+            pm.ExecuteRelevantPatches(patches, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
-            Assert.AreEqual(2, log.Count);
-            Assert.AreEqual("", PatchesToString(executed.ToArray()));
+            Assert.AreEqual("ErrorInExecution C1: 1.0 <= v < 2.0 --> 2.0, " +
+                            "MissingVersion C1: 2.0 <= v < 3.0 --> 3.0",
+                string.Join(", ", context.Errors.Select(x=>x.ToString())));
+            Assert.AreEqual("C1i1.0", PatchesToString(executed.ToArray()));
+            Assert.AreEqual(4, log.Count);
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
-            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[2].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[3].ToString());
+            Assert.AreEqual("[C1: 1.0] ExecutionFinished. Successful", log[1].ToString());
             Assert.AreEqual(4, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
             Assert.AreEqual("1, C1: Install Successful, 1.0", PackagesToString(packages[1]));
             Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[2]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Successful, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Faulty, 2.0", PackagesToString(packages[3]));
         }
+
         [TestMethod]
         public void PatchingExec_SkipPatch_MoreFaultyChains()
         {
@@ -747,7 +746,6 @@ namespace SenseNet.Packaging.Tests
                 executed.Add(patch);
             }
 
-            var installed = new SnComponentDescriptor[0];
             var patches = new ISnPatch[]
             {
                 // Problem in the installer
@@ -760,28 +758,83 @@ namespace SenseNet.Packaging.Tests
                 Inst("C2", "v1.0", null, ctx => { Execute(ctx.CurrentPatch); }),
                 // There is no problem
                 Patch("C3", "2.0 <= v < 3.0", "v3.0", ctx => { Execute(ctx.CurrentPatch); }),
-                Patch("C3", "1.0 <= v < 2.0", "v2.0", ctx => { throw new Exception("Err"); }),
+                Patch("C3", "1.0 <= v < 2.0", "v2.0", ctx => { Execute(ctx.CurrentPatch); }),
                 Inst("C3", "v1.0", null, ctx => { Execute(ctx.CurrentPatch); }),
             };
 
             // ACTION
             var context = new PatchExecutionContext(null, LogMessage);
             var pm = new PatchManager(context);
-            pm.ExecuteRelevantPatches(patches, installed, context);
+            pm.ExecuteRelevantPatches(patches, context);
 
             // ASSERT
-            Assert.AreEqual(0, context.Errors.Length);
-            Assert.AreEqual(2, log.Count);
-            Assert.AreEqual("", PatchesToString(executed.ToArray()));
+            Assert.AreEqual(7, context.Errors.Count);
+            Assert.AreEqual("ErrorInExecution C1: 1.0, " +
+                            "MissingVersion C1: 1.0 <= v < 2.0 --> 2.0, " +
+                            "MissingVersion C1: 2.0 <= v < 3.0 --> 3.0, " +
+                            "ErrorInExecution C2: 1.0 <= v < 2.0 --> 2.0, " +
+                            "MissingVersion C1: 1.0 <= v < 2.0 --> 2.0, " +
+                            "MissingVersion C1: 2.0 <= v < 3.0 --> 3.0, " +
+                            "MissingVersion C2: 2.0 <= v < 3.0 --> 3.0",
+                string.Join(", ", context.Errors.Select(x => x.ToString())));
+
+            Assert.AreEqual("C2i1.0 C3i1.0 C3p2.0 C3p3.0", PatchesToString(executed.ToArray()));
+            Assert.AreEqual(12, log.Count);
             Assert.AreEqual("[C1: 1.0] ExecutionStart.", log[0].ToString());
             Assert.AreEqual("[C1: 1.0] ExecutionFinished. Faulty", log[1].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[2].ToString());
-            Assert.AreEqual("[C1: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[3].ToString());
-            Assert.AreEqual(4, packages.Count);
+            Assert.AreEqual("[C2: 1.0] ExecutionStart.", log[2].ToString());
+            Assert.AreEqual("[C2: 1.0] ExecutionFinished. Successful", log[3].ToString());
+            Assert.AreEqual("[C3: 1.0] ExecutionStart.", log[4].ToString());
+            Assert.AreEqual("[C3: 1.0] ExecutionFinished. Successful", log[5].ToString());
+            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[6].ToString());
+            Assert.AreEqual("[C2: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Faulty", log[7].ToString());
+            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionStart.", log[8].ToString());
+            Assert.AreEqual("[C3: 1.0 <= v < 2.0 --> 2.0] ExecutionFinished. Successful", log[9].ToString());
+            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionStart.", log[10].ToString());
+            Assert.AreEqual("[C3: 2.0 <= v < 3.0 --> 3.0] ExecutionFinished. Successful", log[11].ToString());
+            Assert.AreEqual(12, packages.Count);
             Assert.AreEqual("1, C1: Install Unfinished, 1.0", PackagesToString(packages[0]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0", PackagesToString(packages[1]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Unfinished, 2.0", PackagesToString(packages[2]));
-            Assert.AreEqual("1, C1: Install Successful, 1.0|2, C1: Patch Successful, 2.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0", PackagesToString(packages[1]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Unfinished, 1.0", PackagesToString(packages[2]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0", PackagesToString(packages[3]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Unfinished, 1.0", PackagesToString(packages[4]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0", PackagesToString(packages[5]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Unfinished, 2.0", PackagesToString(packages[6]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Faulty, 2.0", PackagesToString(packages[7]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Faulty, 2.0|" +
+                            "5, C3: Patch Unfinished, 2.0", PackagesToString(packages[8]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Faulty, 2.0|" +
+                            "5, C3: Patch Successful, 2.0", PackagesToString(packages[9]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Faulty, 2.0|" +
+                            "5, C3: Patch Successful, 2.0|" +
+                            "6, C3: Patch Unfinished, 3.0", PackagesToString(packages[10]));
+            Assert.AreEqual("1, C1: Install Faulty, 1.0|" +
+                            "2, C2: Install Successful, 1.0|" +
+                            "3, C3: Install Successful, 1.0|" +
+                            "4, C2: Patch Faulty, 2.0|" +
+                            "5, C3: Patch Successful, 2.0|" +
+                            "6, C3: Patch Successful, 3.0", PackagesToString(packages[11]));
         }
 
     }

--- a/src/Tests/SenseNet.Packaging.Tests/PatchingSelfTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PatchingSelfTests.cs
@@ -61,7 +61,7 @@ namespace SenseNet.Packaging.Tests
         public void Patching_SelfTest_CreatePatch()
         {
             // "C1: 1.0 <= v < 1.0, v1.2"
-            var patch = Patch("C1", "1.0 <= v < 1.0", "v1.2", null);
+            var patch = Patch("C1", "1.0 <= v < 1.0", "v1.2");
 
             Assert.AreEqual("C1", patch.ComponentId);
             Assert.AreEqual(Version.Parse("1.2"), patch.Version);

--- a/src/Tests/SenseNet.Packaging.Tests/PatchingTestBase.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PatchingTestBase.cs
@@ -246,6 +246,17 @@ namespace SenseNet.Packaging.Tests
         /// <param name="id">ComponentId</param>
         /// <param name="version">Target version</param>
         /// <param name="boundary">Complex source version. Example: "1.1 &lt;= v &lt;= 1.1"</param>
+        /// <returns></returns>
+        protected SnPatch Patch(string id, string boundary, string version)
+        {
+            return Patch(id, boundary, version, null, null);
+        }
+        /// <summary>
+        /// Creates a patch for test purposes.
+        /// </summary>
+        /// <param name="id">ComponentId</param>
+        /// <param name="version">Target version</param>
+        /// <param name="boundary">Complex source version. Example: "1.1 &lt;= v &lt;= 1.1"</param>
         /// <param name="dependencies">Dependency array. Use null if there is no dependencies.</param>
         /// <returns></returns>
         protected SnPatch Patch(string id, string boundary, string version, Dependency[] dependencies)
@@ -257,6 +268,18 @@ namespace SenseNet.Packaging.Tests
                 Boundary = ParseBoundary(boundary),
                 Dependencies = dependencies
             };
+        }
+        /// <summary>
+        /// Creates a patch for test purposes.
+        /// </summary>
+        /// <param name="id">ComponentId</param>
+        /// <param name="version">Target version</param>
+        /// <param name="boundary">Complex source version. Example: "1.1 &lt;= v &lt;= 1.1"</param>
+        /// <param name="action">Function of execution</param>
+        /// <returns></returns>
+        protected SnPatch Patch(string id, string boundary, string version, Action<PatchExecutionContext> action)
+        {
+            return Patch(id, boundary, version, null, action);
         }
         /// <summary>
         /// Creates a patch for test purposes.

--- a/src/Tests/SenseNet.Packaging.Tests/PatchingVersionTests.cs
+++ b/src/Tests/SenseNet.Packaging.Tests/PatchingVersionTests.cs
@@ -62,7 +62,7 @@ namespace SenseNet.Packaging.Tests
 
             try
             {
-                ValidatePatch(Patch(null, "1.0 <= v <= 1.0", "v1.2", null));
+                ValidatePatch(Patch(null, "1.0 <= v <= 1.0", "v1.2"));
                 Assert.Fail();
             }
             catch (InvalidPackageException e)
@@ -72,7 +72,7 @@ namespace SenseNet.Packaging.Tests
 
             try
             {
-                ValidatePatch(Patch(string.Empty, "1.0 <= v <= 1.0", "v1.2", null));
+                ValidatePatch(Patch(string.Empty, "1.0 <= v <= 1.0", "v1.2"));
                 Assert.Fail();
             }
             catch (InvalidPackageException e)
@@ -82,7 +82,7 @@ namespace SenseNet.Packaging.Tests
 
             try
             {
-                ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", null, null));
+                ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", null));
                 Assert.Fail();
             }
             catch (InvalidPackageException e)
@@ -92,7 +92,7 @@ namespace SenseNet.Packaging.Tests
 
             try
             {
-                ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", "v0.9", null));
+                ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", "v0.9"));
                 Assert.Fail();
             }
             catch (InvalidPackageException e)
@@ -109,12 +109,12 @@ namespace SenseNet.Packaging.Tests
             // (C1:        v <= 1.0, v1.2) (C1: 0.0.0.0 <= v <= 1.0, v1.2)
             // (C1: 1.0 <= v       , v1.2) (C1: 1.0     <= v <  1.2, v1.2)
 
-            var patch = Patch("C1", "       v <= 1.0", "v1.2", null);
+            var patch = Patch("C1", "       v <= 1.0", "v1.2");
             ValidatePatch(patch);
             Assert.AreEqual(Version.Parse("0.0"), patch.Boundary.MinVersion);
             Assert.IsFalse(patch.Boundary.MinVersionIsExclusive);
 
-            patch = Patch("C1", "1.0 <= v       ", "v1.2", null);
+            patch = Patch("C1", "1.0 <= v       ", "v1.2");
             ValidatePatch(patch);
             Assert.AreEqual(patch.Version, patch.Boundary.MaxVersion);
             Assert.IsTrue(patch.Boundary.MaxVersionIsExclusive);
@@ -127,7 +127,7 @@ namespace SenseNet.Packaging.Tests
             {
                 try
                 {
-                    ValidatePatch(Patch("C1", boundary, "v1.2", null));
+                    ValidatePatch(Patch("C1", boundary, "v1.2"));
                     Assert.Fail("The expected exception was not thrown.");
                 }
                 catch (InvalidPackageException e)
@@ -149,7 +149,7 @@ namespace SenseNet.Packaging.Tests
             //  8 (C1: 1.1 <  v <  1.0, v1.2) Max is less than min
 
             // Case 1: no error
-            ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", "v1.2", null));
+            ValidatePatch(Patch("C1", "1.0 <= v <= 1.0", "v1.2"));
             // Case 2-8: throw InvalidPackageException
             CheckError("1.0 <= v <  1.0", PackagingExceptionType.InvalidInterval);
             CheckError("1.0 <  v <= 1.0", PackagingExceptionType.InvalidInterval);
@@ -181,12 +181,12 @@ namespace SenseNet.Packaging.Tests
             // (C1: 1.1 <= v <= 1.1, v1.3) (C1: 1.1 <= v <= 1.1, v1.4) Sources are the same
 
             CheckError(
-                Patch("C1", "1.1 <= v <= 1.1", "v1.3", null),
-                Patch("C1", "1.2 <= v <= 1.2", "v1.3", null),
+                Patch("C1", "1.1 <= v <= 1.1", "v1.3"),
+                Patch("C1", "1.2 <= v <= 1.2", "v1.3"),
                 PackagingExceptionType.TargetVersionsAreTheSame);
             CheckError(
-                Patch("C1", "1.1 <= v <= 1.1", "v1.3", null),
-                Patch("C1", "1.1 <= v <= 1.1", "v1.4", null),
+                Patch("C1", "1.1 <= v <= 1.1", "v1.3"),
+                Patch("C1", "1.1 <= v <= 1.1", "v1.4"),
                 PackagingExceptionType.SourceVersionsAreTheSame);
 
             // Patch1                      Patch2                      Error
@@ -198,21 +198,21 @@ namespace SenseNet.Packaging.Tests
             // (C1: 1.0 <= v <  2.0, v2.0) (C1: 1.9 <= v <  3.0, v3.0) Overlapped
 
             ValidatePatches(
-                Patch("C1", "1.0 <= v <  2.0", "v2.0", null),
-                Patch("C1", "2.0 <  v <  3.0", "v3.0", null));
+                Patch("C1", "1.0 <= v <  2.0", "v2.0"),
+                Patch("C1", "2.0 <  v <  3.0", "v3.0"));
             ValidatePatches(
-                Patch("C1", "1.0 <= v <= 2.0", "v2.0", null),
-                Patch("C1", "2.0 <  v <  3.0", "v3.0", null));
+                Patch("C1", "1.0 <= v <= 2.0", "v2.0"),
+                Patch("C1", "2.0 <  v <  3.0", "v3.0"));
             ValidatePatches(
-                Patch("C1", "1.0 <= v <  2.0", "v2.0", null),
-                Patch("C1", "2.0 <= v <  3.0", "v3.0", null));
+                Patch("C1", "1.0 <= v <  2.0", "v2.0"),
+                Patch("C1", "2.0 <= v <  3.0", "v3.0"));
             CheckError(
-                Patch("C1", "1.0 <= v <= 2.0", "v2.0", null),
-                Patch("C1", "2.0 <= v <  3.0", "v3.0", null),
+                Patch("C1", "1.0 <= v <= 2.0", "v2.0"),
+                Patch("C1", "2.0 <= v <  3.0", "v3.0"),
                 PackagingExceptionType.OverlappedIntervals);
             CheckError(
-                Patch("C1", "1.0 <= v <  2.0", "v2.0", null),
-                Patch("C1", "1.9 <= v <  3.0", "v3.0", null),
+                Patch("C1", "1.0 <= v <  2.0", "v2.0"),
+                Patch("C1", "1.9 <= v <  3.0", "v3.0"),
                 PackagingExceptionType.OverlappedIntervals);
         }
         [TestMethod]
@@ -368,7 +368,7 @@ namespace SenseNet.Packaging.Tests
                 var segments = x.TrimStart('(').TrimEnd(')').Split(':');
                 var id = segments[0].Trim();
                 segments = segments[1].Trim().Split(',');
-                return Patch(id, segments[0].Trim(), segments[1].Trim(), null);
+                return Patch(id, segments[0].Trim(), segments[1].Trim());
             });
         }
 


### PR DESCRIPTION
Please see the rewritten patching algorithm. After changes the patch execution skips all faulty execution and its dependencies but manages well all successful execution. A good start point is the debugging **PatchingExec_SkipPatch_MoreFaultyChains** test.