### PR TITLE
Default client parameters do not override configured values.

### DIFF
--- a/src/Services.Core/Authentication/IdentityServer4/IdentityServerExtensions.cs
+++ b/src/Services.Core/Authentication/IdentityServer4/IdentityServerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using SenseNet.Services.Core.Authentication.IdentityServer4;
 
@@ -24,16 +25,18 @@ namespace SenseNet.Extensions.DependencyInjection
             services.Configure<ClientRequestOptions>(options =>
             {
                 // add default clients
-                options.Clients.Add(new SnIdentityServerClient
-                {
-                    ClientType = "adminui",
-                    ClientId = "spa"
-                });
-                options.Clients.Add(new SnIdentityServerClient
-                {
-                    ClientType = "client",
-                    ClientId = "client"
-                });
+                if (options.Clients.All(c => c.ClientType != "adminui"))
+                    options.Clients.Add(new SnIdentityServerClient
+                    {
+                        ClientType = "adminui",
+                        ClientId = "adminui"
+                    });
+                if (options.Clients.All(c => c.ClientType != "client"))
+                    options.Clients.Add(new SnIdentityServerClient
+                    {
+                        ClientType = "client",
+                        ClientId = "client"
+                    });
 
                 // developers can extend or modify the list here
                 configure?.Invoke(options);


### PR DESCRIPTION
This PR also changes the default admin ui client id to `adminui`.