### PR TITLE
Correct XML comment for cancellationToken parameters.

### DIFF
--- a/src/ContentRepository/Content.cs
+++ b/src/ContentRepository/Content.cs
@@ -667,7 +667,7 @@ namespace SenseNet.ContentRepository
         /// Loads a Content by the provided id.
         /// </summary>
         /// <param name="id">Content id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The latest accessible version of the Content.</returns>
         public static async Task<Content> LoadAsync(int id, CancellationToken cancellationToken)
         {
@@ -690,7 +690,7 @@ namespace SenseNet.ContentRepository
         /// Loads a Content by the provided path.
         /// </summary>
         /// <param name="path">Content path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The latest accessible version of the Content.</returns>
         public static async Task<Content> LoadAsync(string path, CancellationToken cancellationToken)
         {
@@ -714,7 +714,7 @@ namespace SenseNet.ContentRepository
         /// </summary>
         /// <param name="id">Content id.</param>
         /// <param name="version">Content version.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<Content> LoadAsync(int id, VersionNumber version, CancellationToken cancellationToken)
         {
             var node = await Node.LoadNodeAsync(id, version, cancellationToken).ConfigureAwait(false);
@@ -737,7 +737,7 @@ namespace SenseNet.ContentRepository
         /// </summary>
         /// <param name="path">Content path.</param>
         /// <param name="version">Content version.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<Content> LoadAsync(string path, VersionNumber version, CancellationToken cancellationToken)
         {
             var node = await Node.LoadNodeAsync(path, version, cancellationToken).ConfigureAwait(false);
@@ -757,7 +757,7 @@ namespace SenseNet.ContentRepository
         /// Loads a Content by the provided id or path.
         /// </summary>
         /// <param name="idOrPath">Content id or path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<Content> LoadByIdOrPathAsync(string idOrPath, CancellationToken cancellationToken)
         {
             var node = await Node.LoadNodeByIdOrPathAsync(idOrPath, cancellationToken).ConfigureAwait(false);

--- a/src/ContentRepository/Search/Indexing/Activities/DistributedIndexingActivity.cs
+++ b/src/ContentRepository/Search/Indexing/Activities/DistributedIndexingActivity.cs
@@ -21,7 +21,7 @@ namespace SenseNet.ContentRepository.Search.Indexing.Activities
         /// </summary>
         /// <param name="onRemote">True if the caller is a message receiver.</param>
         /// <param name="isFromMe">True if the source of the activity is in the current appDomain.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public override async STT.Task DoActionAsync(bool onRemote, bool isFromMe, CancellationToken cancellationToken)
         {
@@ -91,7 +91,7 @@ namespace SenseNet.ContentRepository.Search.Indexing.Activities
         /// Waits for a release signal that indicates that this activity has been executed
         /// successfully in the background.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public async STT.Task WaitForCompleteAsync(CancellationToken cancellationToken)
         {

--- a/src/ContentRepository/Search/Indexing/Activities/IndexingActivityBase.cs
+++ b/src/ContentRepository/Search/Indexing/Activities/IndexingActivityBase.cs
@@ -148,7 +148,7 @@ namespace SenseNet.ContentRepository.Search.Indexing.Activities
         /// <summary>
         /// Defines the customizable method to reach the activity's main goal.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         protected abstract STT.Task<bool> ProtectedExecuteAsync(CancellationToken cancellationToken);
         

--- a/src/ContentRepository/Search/Indexing/IndexManager.cs
+++ b/src/ContentRepository/Search/Indexing/IndexManager.cs
@@ -49,7 +49,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// If "consoleOut" is not null, writes progress and debug messages into it.
         /// </summary>
         /// <param name="consoleOut">A <see cref="TextWriter"/> instance or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static async STT.Task StartAsync(TextWriter consoleOut, CancellationToken cancellationToken)
         {
@@ -93,7 +93,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// <summary>
         /// Deletes the existing index. Called before making a brand new index.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static STT.Task ClearIndexAsync(CancellationToken cancellationToken)
         {
@@ -106,7 +106,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// Registers an indexing activity in the database.
         /// </summary>
         /// <param name="activity">The activity to register.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static STT.Task RegisterActivityAsync(IndexingActivityBase activity, CancellationToken cancellationToken)
         {
@@ -119,7 +119,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// Dependent activity execution starts after the previously blocker activity is completed.
         /// </summary>
         /// <param name="activity">The activity to execute.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static STT.Task ExecuteActivityAsync(IndexingActivityBase activity, CancellationToken cancellationToken)
         {
@@ -166,7 +166,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// <summary>
         /// Deletes all activities from the database.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static STT.Task DeleteAllIndexingActivitiesAsync(CancellationToken cancellationToken)
         {

--- a/src/Search/Indexing/IIndexingEngine.cs
+++ b/src/Search/Indexing/IIndexingEngine.cs
@@ -26,14 +26,14 @@ namespace SenseNet.Search.Indexing
         /// ConsoleOut can be used for writing interactive messages if the system is running under an administrative tool.
         /// </summary>
         /// <param name="consoleOut">Console to write messages to.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task StartAsync(TextWriter consoleOut, CancellationToken cancellationToken);
 
         /// <summary>
         /// Stops the indexing and releases all inner and outer resources.  This is not a destructor.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task ShutDownAsync(CancellationToken cancellationToken);
 
@@ -62,7 +62,7 @@ namespace SenseNet.Search.Indexing
         /// <summary>
         /// Deletes the current index and creates a brand new empty one.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task ClearIndexAsync(CancellationToken cancellationToken);
 
@@ -70,7 +70,7 @@ namespace SenseNet.Search.Indexing
         /// Returns an IndexingActivityStatus instance that was associated to the index state.
         /// Called once in the system startup sequence and periodically in the index health check.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the indexing activity status.</returns>
         Task<IndexingActivityStatus> ReadActivityStatusFromIndexAsync(CancellationToken cancellationToken);
 
@@ -79,7 +79,7 @@ namespace SenseNet.Search.Indexing
         /// In heavy load the status writing is not as dense than the index writing.
         /// </summary>
         /// <param name="state">The indexing activity state to write.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task WriteActivityStatusToIndexAsync(IndexingActivityStatus state, CancellationToken cancellationToken);
 
@@ -97,7 +97,7 @@ namespace SenseNet.Search.Indexing
         /// <param name="deletions">Contains terms that define the documents to delete. Can be null or empty.</param>
         /// <param name="updates">Contains term-document pairs that define the refreshed items. Can be null or empty.</param>
         /// <param name="additions">Contains documents to add to index.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task WriteIndexAsync(IEnumerable<SnTerm> deletions, IEnumerable<DocumentUpdate> updates,
             IEnumerable<IndexDocument> additions, CancellationToken cancellationToken);

--- a/src/Storage/Data/DataProvider.cs
+++ b/src/Storage/Data/DataProvider.cs
@@ -116,7 +116,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// LongTextProperties: long text values that can be lazy loaded.
         /// DynamicProperties: all dynamic property values except binaries and long texts.
         /// </param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         /// <exception cref="NodeAlreadyExistsException">A Node with this path already exists in the database.</exception>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
@@ -176,7 +176,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// DynamicProperties: All dynamic property values except the binaries and long texts.
         /// </param>
         /// <param name="versionIdsToDelete">Defines the versions that need to be deleted. Can be empty but not null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="originalPath">Contains the node's original path if it has been renamed. Null if the name has not changed.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         /// <exception cref="ContentNotFoundException">Any part of Node identified by [nodeHeadData].Id or [versionData].Id is missing.</exception>
@@ -242,7 +242,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// DynamicProperties: All dynamic property values except the binaries and long texts.
         /// </param>
         /// <param name="versionIdsToDelete">Defines the versions that need to be deleted. Can be empty but not null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="expectedVersionId">Id of the target version. 0 means: need to create a new version.</param>
         /// <param name="originalPath">Contains the node's original path if it has been renamed. Null if the name has not changed.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
@@ -280,7 +280,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="nodeHeadData">Head data of the node. Contains identity information, place in the 
         /// content tree and the most important not-versioned property values.</param>
         /// <param name="versionIdsToDelete">Defines the versions that need to be deleted. Can be empty but not null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         /// <exception cref="ContentNotFoundException">Any part of Node identified by [nodeHeadData].Id is missing.</exception>
         /// <exception cref="NodeIsOutOfDateException">The change you want to save is based on outdated basic data.</exception>
@@ -306,7 +306,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// 7 - Return the collected NodeData set.
         /// </remarks>
         /// <param name="versionIds">VersionIds of nodes to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded NodeData set.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -322,7 +322,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="nodeHeadData">Head data of the node. Contains identity information, place in the 
         /// content tree and the most important not-versioned property values.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         /// <exception cref="NodeIsOutOfDateException">The operation was initiated on outdated data.</exception>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
@@ -336,7 +336,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="sourceNodeHeadData">Head data of the node to move.</param>
         /// <param name="targetNodeId">Identifier of the target container.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task MoveNodeAsync(NodeHeadData sourceNodeHeadData, int targetNodeId,
             CancellationToken cancellationToken);
@@ -347,7 +347,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">Id of the requested version.</param>
         /// <param name="propertiesToLoad">Ids of requested <see cref="PropertyType"/>s.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded Dictionary&lt;int, string&gt; instance.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -359,7 +359,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">Id of the requested version.</param>
         /// <param name="propertyTypeId">Requested PropertyTypeId.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded <see cref="BinaryDataValue"/> instance or null.</returns>
         public abstract Task<BinaryDataValue> LoadBinaryPropertyValueAsync(int versionId, int propertyTypeId,
             CancellationToken cancellationToken);
@@ -368,7 +368,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Checks if a node exists with the provided path.
         /// </summary>
         /// <param name="path">Path of a node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a boolean value
         /// that is true if the database contains a node with the provided path.</returns>
         public abstract Task<bool> NodeExistsAsync(string path, CancellationToken cancellationToken);
@@ -380,7 +380,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns null if the requested object does not exist in the database.
         /// </summary>
         /// <param name="path">Repository path of the requested node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded <see cref="NodeHead"/> instance or null.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -392,7 +392,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns null if the requested object does not exist in the database.
         /// </summary>
         /// <param name="nodeId">Id of the requested node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded <see cref="NodeHead"/> instance or null.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -404,7 +404,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns null if the requested object does not exist in the database.
         /// </summary>
         /// <param name="versionId">Id of the requested version.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded <see cref="NodeHead"/> instance or null.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -415,7 +415,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Loads a set of <see cref="NodeHead"/> instances.
         /// </summary>
         /// <param name="nodeIds">The requested node ids.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns></returns>
         public abstract Task<IEnumerable<NodeHead>> LoadNodeHeadsAsync(IEnumerable<int> nodeIds,
             CancellationToken cancellationToken);
@@ -424,14 +424,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns version numbers representing all versions of the requested <see cref="Node"/>.
         /// </summary>
         /// <param name="nodeId">Node identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of version numbers.</returns>
         public abstract Task<IEnumerable<NodeHead.NodeVersion>> GetVersionNumbersAsync(int nodeId, CancellationToken cancellationToken);
         /// <summary>
         /// Returns version numbers representing all versions of the requested <see cref="Node"/>.
         /// </summary>
         /// <param name="path">Node path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of version numbers.</returns>
         public abstract Task<IEnumerable<NodeHead.NodeVersion>> GetVersionNumbersAsync(string path, CancellationToken cancellationToken);
 
@@ -441,7 +441,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="paths">Node path list.</param>
         /// <param name="resolveAll">Resolve all paths or only the first one that is found.</param>
         /// <param name="resolveChildren">Resolve child content or not.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of collected node heads.</returns>
         public abstract Task<IEnumerable<NodeHead>> LoadNodeHeadsFromPredefinedSubTreesAsync(IEnumerable<string> paths, bool resolveAll, bool resolveChildren,
             CancellationToken cancellationToken);
@@ -453,14 +453,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <remarks>This methods expects a flattened list of node types. It does not return nodes of derived types.</remarks>
         /// <param name="nodeTypeIds">Array of node type ids. </param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of nodes of the requested types.</returns>
         public abstract Task<int> InstanceCountAsync(int[] nodeTypeIds, CancellationToken cancellationToken);
         /// <summary>
         /// Gets the ids of nodes that are children of the provided parent. Only direct children are collected, not the whole subtree.
         /// </summary>
         /// <param name="parentId">Parent node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps child node identifiers.</returns>
         public abstract Task<IEnumerable<int>> GetChildrenIdentifiersAsync(int parentId, CancellationToken cancellationToken);
         /// <summary>
@@ -471,7 +471,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="pathStart">Case insensitive repository paths of relevant subtrees or null.</param>
         /// <param name="orderByPath">True if the result set need to be ordered by Path.</param>
         /// <param name="name">Name of the relevant <see cref="Node"/>s or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         public abstract Task<IEnumerable<int>> QueryNodesByTypeAndPathAndNameAsync(int[] nodeTypeIds, string[] pathStart,
             bool orderByPath, string name, CancellationToken cancellationToken);
@@ -483,7 +483,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="pathStart">Case insensitive repository path of the relevant subtree or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
         /// <param name="properties">List of properties that need to be included in the query expression.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         public abstract Task<IEnumerable<int>> QueryNodesByTypeAndPathAndPropertyAsync(int[] nodeTypeIds, string pathStart,
             bool orderByPath, List<QueryPropertyData> properties, CancellationToken cancellationToken);
@@ -495,7 +495,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="referenceName">Name of the reference property to search for.</param>
         /// <param name="referredNodeId">Id of a referred node that the property value should contain.</param>
         /// <param name="nodeTypeIds">Ids of relevant NodeTypes or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         public abstract Task<IEnumerable<int>> QueryNodesByReferenceAndTypeAsync(string referenceName, int referredNodeId,
             int[] nodeTypeIds, CancellationToken cancellationToken);
@@ -523,14 +523,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <remarks>Not all types will be returned, only the ones that should be allowed on the target container.</remarks>
         /// <param name="nodeId">Node identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of node types in a subtree.</returns>
         public abstract Task<IEnumerable<NodeType>> LoadChildTypesToAllowAsync(int nodeId, CancellationToken cancellationToken);
         /// <summary>
         /// Gets a list of content list types in a subtree.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps
         /// a list of content list types that are found in a subtree.</returns>
         public abstract Task<List<ContentListType>> GetContentListTypesInTreeAsync(string path, CancellationToken cancellationToken);
@@ -544,7 +544,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="path">The requested path.</param>
         /// <param name="timeLimit">A <see cref="DateTime"/> value, older tree locks than that are considered to be expired.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the Id of the newly created tree lock or 0.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <c>path</c> is null.</exception>
         /// <exception cref="InvalidPathException">Thrown when <c>path</c> is invalid.</exception>
@@ -558,7 +558,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="path">The requested path.</param>
         /// <param name="timeLimit">An expiration time limit. Older tree locks are considered
         /// to be expired and are ignored.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a boolean value
         /// that is true if the path is locked.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <c>path</c> is null.</exception>
@@ -572,7 +572,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Deletes one or more tree locks by the provided Id set.
         /// </summary>
         /// <param name="lockIds">Ids of the tree locks to delete.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -580,7 +580,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Loads all existing tree locks (including expired elements) as an Id, Path dictionary.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the result as an Id, Path dictionary.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -595,7 +595,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">Id of the requested version.</param>
         /// <param name="indexDoc">The serialized <see cref="IndexDocument"/> that will be saved.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the modified VersionTimestamp or 0L.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         /// <exception cref="OperationCanceledException">The operation has been cancelled.</exception>
@@ -606,7 +606,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the index document for the provided version ids.
         /// </summary>
         /// <param name="versionIds">Version id array.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the index document array.</returns>
         public abstract Task<IEnumerable<IndexDocumentData>> LoadIndexDocumentsAsync(IEnumerable<int> versionIds, CancellationToken cancellationToken);
 
@@ -619,7 +619,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="fromId">Starting node id.</param>
         /// <param name="toId">Max node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the list of node ids.</returns>
         public abstract Task<IEnumerable<int>> LoadNotIndexedNodeIdsAsync(int fromId, int toId, CancellationToken cancellationToken);
 
@@ -655,7 +655,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets the latest IndexingActivityId or 0.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the latest IndexingActivity Id ot 0.</returns>
         public abstract Task<int> GetLastIndexingActivityIdAsync(
             CancellationToken cancellationToken);
@@ -671,7 +671,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="executingUnprocessedActivities">True if the method is called during executing
         /// unprocessed indexing activities at system startup.</param>
         /// <param name="activityFactory">Factory class for creating activity instances.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the array of indexing activities.</returns>
         public abstract Task<IIndexingActivity[]> LoadIndexingActivitiesAsync(int fromId, int toId, int count,
             bool executingUnprocessedActivities, IIndexingActivityFactory activityFactory, CancellationToken cancellationToken);
@@ -682,7 +682,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="executingUnprocessedActivities">True if the method is called during executing
         /// unprocessed indexing activities at system startup.</param>
         /// <param name="activityFactory">Factory class for creating activity instances.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the array of indexing activities.</returns>
         public abstract Task<IIndexingActivity[]> LoadIndexingActivitiesAsync(int[] gaps, bool executingUnprocessedActivities,
             IIndexingActivityFactory activityFactory, CancellationToken cancellationToken);
@@ -696,7 +696,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="maxCount">Maximum number of loaded activities.</param>
         /// <param name="runningTimeoutInSeconds">Timeout for running activities.</param>
         /// <param name="waitingActivityIds">An array of activities that this appdomain is waiting for.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the executable activity result.</returns>
         public abstract Task<ExecutableIndexingActivitiesResult> LoadExecutableIndexingActivitiesAsync(
             IIndexingActivityFactory activityFactory, int maxCount, int runningTimeoutInSeconds, int[] waitingActivityIds,
@@ -705,7 +705,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Registers an indexing activity in the database.
         /// </summary>
         /// <param name="activity">Indexing activity.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task RegisterIndexingActivityAsync(IIndexingActivity activity, CancellationToken cancellationToken);
         /// <summary>
@@ -713,7 +713,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="indexingActivityId">Indexing activity id.</param>
         /// <param name="runningState">A state to set in the database.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task UpdateIndexingActivityRunningStateAsync(int indexingActivityId, IndexingActivityRunningState runningState,
             CancellationToken cancellationToken);
@@ -721,19 +721,19 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Refresh the lock time of multiple indexing activities.
         /// </summary>
         /// <param name="waitingIds">Activity ids that we are still working on or waiting for.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task RefreshIndexingActivityLockTimeAsync(int[] waitingIds, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes finished activities. Called by a cleanup background process.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task DeleteFinishedIndexingActivitiesAsync(CancellationToken cancellationToken);
         /// <summary>
         /// Deletes all activities from the database.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task DeleteAllIndexingActivitiesAsync(CancellationToken cancellationToken);
 
@@ -742,7 +742,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets the whole schema definition from the database, including property types, node types and content list types.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded <see cref="RepositorySchemaData"/> instance.</returns>
         public abstract Task<RepositorySchemaData> LoadSchemaAsync(
             CancellationToken cancellationToken);
@@ -762,7 +762,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// 3 - Locks the schema exclusively against other modifications and return a schema lock token.
         /// </remarks>
         /// <param name="schemaTimestamp">The current known timestamp of the schema.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the generated schema lock token.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         public abstract Task<string> StartSchemaUpdateAsync(long schemaTimestamp, CancellationToken cancellationToken);
@@ -776,7 +776,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// 2 - Returns a newly generated schemaTimestamp.
         /// </remarks>
         /// <param name="schemaLock">Schema lock token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new schema timestamp.</returns>
         /// <exception cref="DataException">The operation causes a database-related error.</exception>
         public abstract Task<long> FinishSchemaUpdateAsync(string schemaLock, CancellationToken cancellationToken);
@@ -787,7 +787,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Writes the <see cref="AuditEventInfo"/> to the database.
         /// </summary>
         /// <param name="auditEvent">The <see cref="AuditEventInfo"/> object that will be saved.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task WriteAuditEventAsync(AuditEventInfo auditEvent,
             CancellationToken cancellationToken);
@@ -797,7 +797,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Intended for internal use.
         /// </summary>
         /// <param name="count">Number of events to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of audit events.</returns>
         public abstract Task<IEnumerable<AuditLogEntry>> LoadLastAuditEventsAsync(int count,
             CancellationToken cancellationToken);
@@ -824,7 +824,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="parentId">Id of the container.</param>
         /// <param name="namebase">Name prefix.</param>
         /// <param name="extension">File extension.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the found file name.</returns>
         public abstract Task<string> GetNameOfLastNodeWithNameBaseAsync(int parentId, string namebase, string extension,
             CancellationToken cancellationToken);
@@ -836,7 +836,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="path">Path of the requested node.</param>
         /// <param name="includeChildren">True if the algorithm should count in all nodes in the whole subtree.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the size of the requested node or subtree.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <c>path</c> is null.</exception>
         /// <exception cref="InvalidPathException">Thrown when <c>path</c> is invalid.</exception>
@@ -849,7 +849,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the count of nodes in a subtree. The number will include the subtree root node.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of nodes.</returns>
         public abstract Task<int> GetNodeCountAsync(string path, CancellationToken cancellationToken);
 
@@ -857,7 +857,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the count of node versions in the subtree defined by the path parameter.
         /// </summary>
         /// <param name="path">Path of the requested subtree.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of versions.</returns>
         public abstract Task<int> GetVersionCountAsync(string path, CancellationToken cancellationToken);
 
@@ -869,7 +869,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// which happens during the installation process.
         /// </summary>
         /// <param name="data">A storage-model structure to install.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task InstallInitialDataAsync(InitialData data, CancellationToken cancellationToken);
 
@@ -877,7 +877,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns the Content tree representation for building the security model.
         /// Every node and leaf contains only the Id, ParentId and OwnerId of the node.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps an enumerable <see cref="EntityTreeNodeData"/>
         /// as the Content tree representation.</returns>
         public abstract Task<IEnumerable<EntityTreeNodeData>> LoadEntityTreeAsync(CancellationToken cancellationToken);
@@ -887,7 +887,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// If this method returns false, the client should call the <see cref="InstallDatabaseAsync"/> method
         /// to prepare the database.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a boolean value
         /// that is true if the database schema is ready.</returns>
         public virtual Task<bool> IsDatabaseReadyAsync(CancellationToken cancellationToken)
@@ -898,7 +898,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Prepares the database schema for accepting new items.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public virtual Task InstallDatabaseAsync(CancellationToken cancellationToken)
         {

--- a/src/Storage/Data/DataStore.cs
+++ b/src/Storage/Data/DataStore.cs
@@ -90,7 +90,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// which happens during the installation process.
         /// </summary>
         /// <param name="data">A storage-model structure to install.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task InstallInitialDataAsync(InitialData data, CancellationToken cancellationToken)
         {
@@ -101,7 +101,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns the Content tree representation for building the security model.
         /// Every node and leaf contains only the Id, ParentId and OwnerId of the node.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps an enumerable <see cref="EntityTreeNodeData"/>
         /// as the Content tree representation.</returns>
         public static Task<IEnumerable<EntityTreeNodeData>> LoadEntityTreeAsync(CancellationToken cancellationToken)
@@ -112,7 +112,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Checks if the database exists and is ready to accept new items.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a bool value that is
         /// true if the database already exists and contains the necessary schema.</returns>
         public static Task<bool> IsDatabaseReadyAsync(CancellationToken cancellationToken)
@@ -124,7 +124,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Creates the database schema and fills it with the necessary initial data.
         /// </summary>
         /// <param name="initialData">Optional initial data.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static async Task InstallDatabaseAsync(InitialData initialData, CancellationToken cancellationToken)
         {
@@ -144,7 +144,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// information stored in the settings and node data parameter objects.</remarks>
         /// <param name="nodeData">Data to save to the database.</param>
         /// <param name="settings">Defines the saving algorithm of the provided data.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new node head
         /// containing the latest version and time identifiers.</returns>
         internal static async Task<NodeHead> SaveNodeAsync(NodeData nodeData, NodeSaveSettings settings, CancellationToken cancellationToken)
@@ -265,7 +265,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="head">A node head representing the node.</param>
         /// <param name="versionId">Version identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a node token
         /// containing the information for constructing the appropriate node object.</returns>
         internal static async Task<NodeToken> LoadNodeAsync(NodeHead head, int versionId, CancellationToken cancellationToken)
@@ -278,7 +278,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="headArray">A node head array representing the nodes to load.</param>
         /// <param name="versionIdArray">Version identifier array containing version ids of individual nodes.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a node token array
         /// containing the information for constructing the appropriate node objects.</returns>
         internal static async Task<NodeToken[]> LoadNodesAsync(NodeHead[] headArray, int[] versionIdArray, CancellationToken cancellationToken)
@@ -330,7 +330,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Deletes a node from the database.
         /// </summary>
         /// <param name="nodeHead">A node data representing the node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static Task DeleteNodeAsync(NodeHead nodeHead, CancellationToken cancellationToken)
         {
@@ -340,7 +340,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Deletes a node from the database.
         /// </summary>
         /// <param name="nodeData">A node data representing the node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static Task DeleteNodeAsync(NodeData nodeData, CancellationToken cancellationToken)
         {
@@ -351,7 +351,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="sourceNodeHead">A node data representing the node to move.</param>
         /// <param name="targetNodeId">Id of the container where the node will be moved.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static async Task MoveNodeAsync(NodeHead sourceNodeHead, int targetNodeId, CancellationToken cancellationToken)
         {
@@ -364,7 +364,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="sourceNodeData">A node data representing the node to move.</param>
         /// <param name="targetNodeId">Id of the container where the node will be moved.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static async Task MoveNodeAsync(NodeData sourceNodeData, int targetNodeId, CancellationToken cancellationToken)
         {
@@ -379,7 +379,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">Version identifier.</param>
         /// <param name="propertiesToLoad">A <see cref="PropertyType"/> id set to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a dictionary
         /// containing the loaded text property values.</returns>
         internal static Task<Dictionary<int, string>> LoadTextPropertyValuesAsync(int versionId, int[] propertiesToLoad, CancellationToken cancellationToken)
@@ -391,7 +391,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">Version identifier.</param>
         /// <param name="propertyTypeId">A <see cref="PropertyType"/> id to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a binary data
         /// containing the information to load the stream.</returns>
         internal static Task<BinaryDataValue> LoadBinaryPropertyValueAsync(int versionId, int propertyTypeId, CancellationToken cancellationToken)
@@ -403,7 +403,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Checks if a node exists with the provided path.
         /// </summary>
         /// <param name="path">Path of a node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a boolean value
         /// that is true if the database contains a node with the provided path.</returns>
         public static async Task<bool> NodeExistsAsync(string path, CancellationToken cancellationToken)
@@ -522,7 +522,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Loads a node head from the database.
         /// </summary>
         /// <param name="path">Path of a node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a node head
         /// for the provided path or null if it does not exist.</returns>
         internal static async Task<NodeHead> LoadNodeHeadAsync(string path, CancellationToken cancellationToken)
@@ -545,7 +545,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Loads a node head from the database.
         /// </summary>
         /// <param name="nodeId">Id of a node.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a node head
         /// for the provided id or null if it does not exist.</returns>
         internal static async Task<NodeHead> LoadNodeHeadAsync(int nodeId, CancellationToken cancellationToken)
@@ -568,7 +568,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Loads a node head from the database.
         /// </summary>
         /// <param name="versionId">Id of a specific node version.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a node head
         /// for the provided version id or null if it does not exist.</returns>
         internal static Task<NodeHead> LoadNodeHeadByVersionIdAsync(int versionId, CancellationToken cancellationToken)
@@ -580,7 +580,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <remarks>This method may return fewer node heads than requested in case not all of them exist.</remarks>
         /// <param name="nodeIds">Ids of the node heads to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of Node heads for the provided ids.</returns>
         internal static async Task<IEnumerable<NodeHead>> LoadNodeHeadsAsync(IEnumerable<int> nodeIds, CancellationToken cancellationToken)
         {
@@ -622,7 +622,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns version numbers representing all versions of the requested <see cref="Node"/>.
         /// </summary>
         /// <param name="nodeId">Node identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of version numbers.</returns>
         public static Task<IEnumerable<NodeHead.NodeVersion>> GetVersionNumbersAsync(int nodeId, CancellationToken cancellationToken)
         {
@@ -632,7 +632,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Returns version numbers representing all versions of the requested <see cref="Node"/>.
         /// </summary>
         /// <param name="path">Node path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of version numbers.</returns>
         public static Task<IEnumerable<NodeHead.NodeVersion>> GetVersionNumbersAsync(string path, CancellationToken cancellationToken)
         {
@@ -646,7 +646,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="paths">Node path list.</param>
         /// <param name="resolveAll">Resolve all paths or only the first one that is found.</param>
         /// <param name="resolveChildren">Resolve child content or not.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of collected node heads.</returns>
         internal static Task<IEnumerable<NodeHead>> LoadNodeHeadsFromPredefinedSubTreesAsync(IEnumerable<string> paths, bool resolveAll, bool resolveChildren, CancellationToken cancellationToken)
         {
@@ -660,7 +660,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <remarks>This methods expects a flattened list of node types. It does not return nodes of derived types.</remarks>
         /// <param name="nodeTypeIds">Array of node type ids. </param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of nodes of the requested types.</returns>
         internal static Task<int> InstanceCountAsync(int[] nodeTypeIds, CancellationToken cancellationToken)
         {
@@ -670,7 +670,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the ids of nodes that are children of the provided parent. Only direct children are collected, not the whole subtree.
         /// </summary>
         /// <param name="parentId">Parent node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps child node identifiers.</returns>
         internal static Task<IEnumerable<int>> GetChildrenIdentifiersAsync(int parentId, CancellationToken cancellationToken)
         {
@@ -681,7 +681,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="pathStart">Case insensitive repository path of the required subtree or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByPathAsync(string pathStart, bool orderByPath, CancellationToken cancellationToken)
         {
@@ -691,7 +691,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Queries <see cref="Node"/>s by their type.
         /// </summary>
         /// <param name="nodeTypeIds">Ids of relevant NodeTypes.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByTypeAsync(int[] nodeTypeIds, CancellationToken cancellationToken)
         {
@@ -704,7 +704,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="nodeTypeIds">Ids of relevant NodeTypes or null.</param>
         /// <param name="pathStart">Case insensitive repository path of the relevant subtree or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByTypeAndPathAsync(int[] nodeTypeIds, string pathStart, bool orderByPath, CancellationToken cancellationToken)
         {
@@ -717,7 +717,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="nodeTypeIds">Ids of relevant NodeTypes or null.</param>
         /// <param name="pathStart">Case insensitive repository paths of relevant subtrees or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByTypeAndPathAsync(int[] nodeTypeIds, string[] pathStart, bool orderByPath, CancellationToken cancellationToken)
         {
@@ -731,7 +731,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="pathStart">Case insensitive repository path of the relevant subtree or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
         /// <param name="name">Name of the relevant <see cref="Node"/>s or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByTypeAndPathAndNameAsync(int[] nodeTypeIds, string pathStart, bool orderByPath, string name, CancellationToken cancellationToken)
         {
@@ -745,7 +745,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="pathStart">Case insensitive repository paths of relevant subtrees or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
         /// <param name="name">Name of the relevant <see cref="Node"/>s or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByTypeAndPathAndNameAsync(int[] nodeTypeIds, string[] pathStart, bool orderByPath, string name, CancellationToken cancellationToken)
         {
@@ -760,7 +760,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="pathStart">Case insensitive repository path of the relevant subtree or null.</param>
         /// <param name="orderByPath">True if the result set needs to be ordered by Path.</param>
         /// <param name="properties">List of properties that need to be included in the query expression.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         public static Task<IEnumerable<int>> QueryNodesByTypeAndPathAndPropertyAsync(int[] nodeTypeIds, string pathStart, bool orderByPath, List<QueryPropertyData> properties, CancellationToken cancellationToken)
         {
@@ -775,7 +775,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="referenceName">Name of the reference property to search for.</param>
         /// <param name="referredNodeId">Id of a referred node that the property value should contain.</param>
         /// <param name="nodeTypeIds">Ids of relevant NodeTypes or null.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the set of found <see cref="Node"/> identifiers.</returns>
         internal static Task<IEnumerable<int>> QueryNodesByReferenceAndTypeAsync(string referenceName, int referredNodeId, int[] nodeTypeIds, CancellationToken cancellationToken)
         {
@@ -789,7 +789,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <remarks>Not all types will be returned, only the ones that should be allowed on the target container.</remarks>
         /// <param name="nodeId">Node identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of node types in a subtree.</returns>
         internal static Task<IEnumerable<NodeType>> LoadChildTypesToAllowAsync(int nodeId, CancellationToken cancellationToken)
         {
@@ -799,7 +799,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets a list of content list types in a subtree.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps
         /// a list of content list types that are found in a subtree.</returns>
         internal static Task<List<ContentListType>> GetContentListTypesInTreeAsync(string path, CancellationToken cancellationToken)
@@ -813,7 +813,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Locks a subtree exclusively. The return value is 0 if the path is locked in the parent axis or in the subtree.
         /// </summary>
         /// <param name="path">Node path to lock.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the newly created
         /// tree lock Id for the requested path or 0.</returns>
         internal static Task<int> AcquireTreeLockAsync(string path, CancellationToken cancellationToken)
@@ -824,7 +824,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Checks whether the provided path is locked.
         /// </summary>
         /// <param name="path">Node path to lock.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a boolean value
         /// that is true if the path is already locked.</returns>
         internal static Task<bool> IsTreeLockedAsync(string path, CancellationToken cancellationToken)
@@ -836,7 +836,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Releases the locks represented by the provided lock id array.
         /// </summary>
         /// <param name="lockIds">Array of lock identifiers.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         internal static Task ReleaseTreeLockAsync(int[] lockIds, CancellationToken cancellationToken)
         {
@@ -845,7 +845,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets all tree locks in the system.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a lock id, path dictionary.</returns>
         internal static Task<Dictionary<int, string>> LoadAllTreeLocksAsync(CancellationToken cancellationToken)
         {
@@ -866,7 +866,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="node">The Node to index.</param>
         /// <param name="skipBinaries">True if binary properties should be skipped.</param>
         /// <param name="isNew">True if the node is new.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the result including
         /// index document data.</returns>
         public static async Task<SavingIndexDocumentDataResult> SaveIndexDocumentAsync(Node node, bool skipBinaries, bool isNew,
@@ -894,7 +894,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="node">The Node to index.</param>
         /// <param name="indexDocumentData">Index document data assembled by previous steps in the save operation.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the resulting index document data.</returns>
         public static async Task<IndexDocumentData> SaveIndexDocumentAsync(Node node, IndexDocumentData indexDocumentData,
             CancellationToken cancellationToken)
@@ -939,7 +939,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="versionId">The id of the target node version.</param>
         /// <param name="indexDoc">Index document assembled by previous steps in the save operation.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new version timestamp.</returns>
         public static async Task<long> SaveIndexDocumentAsync(int versionId, IndexDocument indexDoc, CancellationToken cancellationToken)
         {
@@ -953,7 +953,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the index document for the provided version id.
         /// </summary>
         /// <param name="versionId">Version identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the index document or null.</returns>
         public static async Task<IndexDocumentData> LoadIndexDocumentByVersionIdAsync(int versionId, CancellationToken cancellationToken)
         {
@@ -964,7 +964,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets index documents for the provided version ids.
         /// </summary>
         /// <param name="versionIds">Version identifiers.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the list of loaded index documents.</returns>
         public static Task<IEnumerable<IndexDocumentData>> LoadIndexDocumentsAsync(IEnumerable<int> versionIds, CancellationToken cancellationToken)
         {
@@ -986,7 +986,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="fromId">Starting node id.</param>
         /// <param name="toId">Max node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the list of node ids.</returns>
         public static Task<IEnumerable<int>> LoadNotIndexedNodeIdsAsync(int fromId, int toId, CancellationToken cancellationToken)
         {
@@ -1032,7 +1032,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the latest IndexingActivityId or 0.
         /// This method is used in the distributed indexing scenario.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static Task<int> GetLastIndexingActivityIdAsync(CancellationToken cancellationToken)
         {
             return DataProvider.GetLastIndexingActivityIdAsync(cancellationToken);
@@ -1048,7 +1048,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="executingUnprocessedActivities">True if the method is called during executing
         /// unprocessed indexing activities at system startup.</param>
         /// <param name="activityFactory">Factory class for creating activity instances.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the array of indexing activities.</returns>
         public static Task<IIndexingActivity[]> LoadIndexingActivitiesAsync(int fromId, int toId, int count, bool executingUnprocessedActivities, IIndexingActivityFactory activityFactory, CancellationToken cancellationToken)
         {
@@ -1062,7 +1062,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="executingUnprocessedActivities">True if the method is called during executing
         /// unprocessed indexing activities at system startup.</param>
         /// <param name="activityFactory">Factory class for creating activity instances.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the array of indexing activities.</returns>
         public static Task<IIndexingActivity[]> LoadIndexingActivitiesAsync(int[] gaps, bool executingUnprocessedActivities, IIndexingActivityFactory activityFactory, CancellationToken cancellationToken)
         {
@@ -1079,7 +1079,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="maxCount">Maximum number of loaded activities.</param>
         /// <param name="runningTimeoutInSeconds">Timeout for running activities.</param>
         /// <param name="waitingActivityIds">An array of activities that this appdomain is waiting for.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the executable activity result.</returns>
         public static Task<ExecutableIndexingActivitiesResult> LoadExecutableIndexingActivitiesAsync(IIndexingActivityFactory activityFactory, int maxCount, int runningTimeoutInSeconds, int[] waitingActivityIds, CancellationToken cancellationToken)
         {
@@ -1089,7 +1089,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Registers an indexing activity in the database.
         /// </summary>
         /// <param name="activity">Indexing activity.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task RegisterIndexingActivityAsync(IIndexingActivity activity, CancellationToken cancellationToken)
         {
@@ -1100,7 +1100,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="indexingActivityId">Indexing activity id.</param>
         /// <param name="runningState">A state to set in the database.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task UpdateIndexingActivityRunningStateAsync(int indexingActivityId, IndexingActivityRunningState runningState, CancellationToken cancellationToken)
         {
@@ -1110,7 +1110,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Refresh the lock time of multiple indexing activities.
         /// </summary>
         /// <param name="waitingIds">Activity ids that we are still working on or waiting for.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task RefreshIndexingActivityLockTimeAsync(int[] waitingIds, CancellationToken cancellationToken)
         {
@@ -1119,7 +1119,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Deletes finished activities. Called by a cleanup background process.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteFinishedIndexingActivitiesAsync(CancellationToken cancellationToken)
         {
@@ -1128,7 +1128,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Deletes all activities from the database.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteAllIndexingActivitiesAsync(CancellationToken cancellationToken)
         {
@@ -1140,7 +1140,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets the whole schema definition from the database, including property types, node types and content list types.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the schema definition.</returns>
         internal static Task<RepositorySchemaData> LoadSchemaAsync(CancellationToken cancellationToken)
         {
@@ -1151,7 +1151,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Initiates a schema update operation and locks the schema exclusively.
         /// </summary>
         /// <param name="schemaTimestamp">The current known timestamp of the schema.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the generated schema lock token.</returns>
         internal static Task<string> StartSchemaUpdateAsync(long schemaTimestamp, CancellationToken cancellationToken)
         {
@@ -1176,7 +1176,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Completes a schema write operation and releases the lock.
         /// </summary>
         /// <param name="schemaLock">The lock token generated by the start operation before.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new schema timestamp.</returns>
         internal static Task<long> FinishSchemaUpdateAsync(string schemaLock, CancellationToken cancellationToken)
         {
@@ -1218,7 +1218,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Writes an audit event to the database.
         /// </summary>
         /// <param name="auditEvent">Audit event info.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task WriteAuditEventAsync(AuditEventInfo auditEvent, CancellationToken cancellationToken)
         {
@@ -1230,7 +1230,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Intended for internal use.
         /// </summary>
         /// <param name="count">Number of events to load.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of audit events.</returns>
         public static Task<IEnumerable<AuditLogEntry>> LoadLastAuditEventsAsync(int count,
             CancellationToken cancellationToken)
@@ -1267,7 +1267,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="parentId">Id of the container.</param>
         /// <param name="namebase">Name prefix.</param>
         /// <param name="extension">File extension.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the found file name.</returns>
         public static Task<string> GetNameOfLastNodeWithNameBaseAsync(int parentId, string namebase, string extension, CancellationToken cancellationToken)
         {
@@ -1280,7 +1280,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="path">Path of the requested node.</param>
         /// <param name="includeChildren">True if the algorithm should count in all nodes in the whole subtree.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the size of the requested node or subtree.</returns>
         public static Task<long> GetTreeSizeAsync(string path, bool includeChildren, CancellationToken cancellationToken)
         {
@@ -1289,7 +1289,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets the count of nodes in the whole Content Repository.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of nodes.</returns>
         public static Task<int> GetNodeCountAsync(CancellationToken cancellationToken)
         {
@@ -1299,7 +1299,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the count of nodes in a subtree. The number will include the subtree root node.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of nodes.</returns>
         public static Task<int> GetNodeCountAsync(string path, CancellationToken cancellationToken)
         {
@@ -1308,7 +1308,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Gets the count of node versions in the whole Content Repository.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of versions.</returns>
         public static Task<int> GetVersionCountAsync(CancellationToken cancellationToken)
         {
@@ -1318,7 +1318,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets the count of node versions in a subtree. The number will include the versions of the subtree root node.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the count of versions.</returns>
         public static Task<int> GetVersionCountAsync(string path, CancellationToken cancellationToken)
         {

--- a/src/Storage/Data/IAccessTokenDataProviderExtension.cs
+++ b/src/Storage/Data/IAccessTokenDataProviderExtension.cs
@@ -14,14 +14,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Deletes all AccessTokens even if they are still valid.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAllAccessTokensAsync(CancellationToken cancellationToken);
         /// <summary>
         /// Saves an access token instance to the database.
         /// </summary>
         /// <param name="token">The access token to save.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task SaveAccessTokenAsync(AccessToken token, CancellationToken cancellationToken);
 
@@ -29,7 +29,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Gets an access token by its id.
         /// </summary>
         /// <param name="accessTokenId">Access token identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps an access token instance or null.</returns>
         Task<AccessToken> LoadAccessTokenByIdAsync(int accessTokenId, CancellationToken cancellationToken);
         /// <summary>
@@ -39,14 +39,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="tokenValue">Token value.</param>
         /// <param name="contentId">Content id.</param>
         /// <param name="feature">Feature identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the found token instance.</returns>
         Task<AccessToken> LoadAccessTokenAsync(string tokenValue, int contentId, string feature, CancellationToken cancellationToken);
         /// <summary>
         /// Gets all tokens related to a user.
         /// </summary>
         /// <param name="userId">The token owner id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps an array of tokens.</returns>
         Task<AccessToken[]> LoadAccessTokensAsync(int userId, CancellationToken cancellationToken);
 
@@ -55,35 +55,35 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="tokenValue">Token value.</param>
         /// <param name="newExpirationDate">New expiration date.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task UpdateAccessTokenAsync(string tokenValue, DateTime newExpirationDate, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes the specified token regardless of expiration date.
         /// </summary>
         /// <param name="tokenValue">Token value.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAccessTokenAsync(string tokenValue, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes all tokens of the provided user.
         /// </summary>
         /// <param name="userId">The token owner id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAccessTokensByUserAsync(int userId, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes all tokens related to a content.
         /// </summary>
         /// <param name="contentId">Content id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAccessTokensByContentAsync(int contentId, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes all access tokens that expired a certain time ago.
         /// Expiration time is determined by the extension implementation.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task CleanupAccessTokensAsync(CancellationToken cancellationToken);
     }

--- a/src/Storage/Data/IPackagingDataProvider.cs
+++ b/src/Storage/Data/IPackagingDataProvider.cs
@@ -14,13 +14,13 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Loads all installed components. The descriptions come from installers
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of <see cref="ComponentInfo"/> objects.</returns>
         Task<IEnumerable<ComponentInfo>> LoadInstalledComponentsAsync(CancellationToken cancellationToken);
         /// <summary>
         /// Loads all components that not successfully installed.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of <see cref="ComponentInfo"/> objects.</returns>
         Task<IEnumerable<ComponentInfo>> LoadIncompleteComponentsAsync(CancellationToken cancellationToken);
         /// <summary>
@@ -30,7 +30,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// of the same component are also represented by separate items in this list, so this is
         /// a package install history.
         /// To get a list of installed components, use the <see cref="LoadInstalledComponentsAsync"/> method.</remarks>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a list of <see cref="Package"/> objects.</returns>
         Task<IEnumerable<Package>> LoadInstalledPackagesAsync(CancellationToken cancellationToken);
 
@@ -38,14 +38,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// Saves a package to the database after execution.
         /// </summary>
         /// <param name="package">The package to save.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task SavePackageAsync(Package package, CancellationToken cancellationToken);
         /// <summary>
         /// Updates package information in the database.
         /// </summary>
         /// <param name="package">The package to update.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task UpdatePackageAsync(Package package, CancellationToken cancellationToken);
 
@@ -55,20 +55,20 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="componentId">Component id.</param>
         /// <param name="packageType">Package type.</param>
         /// <param name="version">Package version.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps true if the package exists.</returns>
         Task<bool> IsPackageExistAsync(string componentId, PackageType packageType, Version version, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes a package from the database by its id.
         /// </summary>
         /// <param name="package">The package to delete.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeletePackageAsync(Package package, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes all packages from the database.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAllPackagesAsync(CancellationToken cancellationToken);
         /// <summary>
@@ -77,7 +77,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// should contain the loaded manifest xml.
         /// </summary>
         /// <param name="package">The package to load the manifest for.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task LoadManifestAsync(Package package, CancellationToken cancellationToken);
     }

--- a/src/Storage/Data/ISharedLockDataProviderExtension.cs
+++ b/src/Storage/Data/ISharedLockDataProviderExtension.cs
@@ -15,7 +15,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Deletes all shared locks from the system. Not intended for external callers.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteAllSharedLocksAsync(CancellationToken cancellationToken);
 
@@ -25,7 +25,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="contentId">Content id.</param>
         /// <param name="lock">Lock token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task CreateSharedLockAsync(int contentId, string @lock, CancellationToken cancellationToken);
         /// <summary>
@@ -34,7 +34,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="contentId">Content id.</param>
         /// <param name="lock">Lock token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task<string> RefreshSharedLockAsync(int contentId, string @lock, CancellationToken cancellationToken);
 
@@ -44,14 +44,14 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <param name="contentId">Content id.</param>
         /// <param name="lock">Lock token.</param>
         /// <param name="newLock"></param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the original lock value if exists.</returns>
         Task<string> ModifySharedLockAsync(int contentId, string @lock, string newLock, CancellationToken cancellationToken);
         /// <summary>
         /// Loads a shared lock value for the specified content id.
         /// </summary>
         /// <param name="contentId">Content id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the loaded lock token.</returns>
         Task<string> GetSharedLockAsync(int contentId, CancellationToken cancellationToken);
         /// <summary>
@@ -59,13 +59,13 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// </summary>
         /// <param name="contentId">Content id.</param>
         /// <param name="lock">Lock token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the original lock value if exists.</returns>
         Task<string> DeleteSharedLockAsync(int contentId, string @lock, CancellationToken cancellationToken);
         /// <summary>
         /// Deletes expired shared locks. Called by the maintenance task.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task CleanupSharedLocksAsync(CancellationToken cancellationToken);
     }

--- a/src/Storage/Data/MsSqlClient/MsSqlDataProvider.cs
+++ b/src/Storage/Data/MsSqlClient/MsSqlDataProvider.cs
@@ -397,7 +397,7 @@ namespace SenseNet.ContentRepository.Storage.Data.MsSqlClient
         /// on the configured database.
         /// </summary>
         /// <param name="scriptName">Resource identifier.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         private async Task ExecuteEmbeddedNonQueryScriptAsync(string scriptName, CancellationToken cancellationToken)
         {

--- a/src/Storage/Data/RelationalDataProviderBase.cs
+++ b/src/Storage/Data/RelationalDataProviderBase.cs
@@ -33,7 +33,7 @@ namespace SenseNet.ContentRepository.Storage.Data
         /// <summary>
         /// Constructs a platform-specific context that is able to hold transaction- and connection-related information.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A new data context object.</returns>
         public abstract SnDataContext CreateDataContext(CancellationToken cancellationToken);
         /* =============================================================================================== Nodes */

--- a/src/Storage/DistributedApplication/Messaging/DistributedAction.cs
+++ b/src/Storage/DistributedApplication/Messaging/DistributedAction.cs
@@ -16,7 +16,7 @@ namespace SenseNet.Communication.Messaging
         /// <summary>
         /// Executes the activity's main action and distributes it to the other app domains in the cluster.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public async Task ExecuteAsync(CancellationToken cancellationToken)
         {
@@ -44,14 +44,14 @@ namespace SenseNet.Communication.Messaging
         /// </summary>
         /// <param name="onRemote">True if the caller is a message receiver.</param>
         /// <param name="isFromMe">True if the source of the activity is in the current appDomain.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public abstract Task DoActionAsync(bool onRemote, bool isFromMe, CancellationToken cancellationToken);
 
         /// <summary>
         /// Distributes the activity to the other app domains in the cluster.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public virtual async Task DistributeAsync(CancellationToken cancellationToken)
         {

--- a/src/Storage/Node.cs
+++ b/src/Storage/Node.cs
@@ -1729,7 +1729,7 @@ namespace SenseNet.ContentRepository.Storage
         /// at least See permission for each item in the result set.
         /// </summary>
         /// <param name="idArray">The IEnumerable&lt;int&gt; that contains the requested ids.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<List<Node>> LoadNodesAsync(IEnumerable<int> idArray, CancellationToken cancellationToken)
         {
             var nodeHeads = await DataStore.LoadNodeHeadsAsync(idArray, cancellationToken).ConfigureAwait(false);
@@ -1974,7 +1974,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </summary>
         /// <typeparam name="T">The requested return type.</typeparam>
         /// <param name="nodeId">Node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A node as the provided derived type.</returns>
         public static async Task<T> LoadAsync<T>(int nodeId, CancellationToken cancellationToken) where T : Node
         {
@@ -1997,7 +1997,7 @@ namespace SenseNet.ContentRepository.Storage
         /// <typeparam name="T">The requested return type.</typeparam>
         /// <param name="nodeId">Node id.</param>
         /// <param name="version">The requested version. For example: new VersionNumber(2, 0).</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A node as the provided derived type.</returns>
         public static async Task<T> LoadAsync<T>(int nodeId, VersionNumber version, CancellationToken cancellationToken) where T : Node
         {
@@ -2018,7 +2018,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </summary>
         /// <typeparam name="T">The requested return type.</typeparam>
         /// <param name="path">Node path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A node as the provided derived type.</returns>
         public static async Task<T> LoadAsync<T>(string path, CancellationToken cancellationToken) where T : Node
         {
@@ -2042,7 +2042,7 @@ namespace SenseNet.ContentRepository.Storage
         /// <typeparam name="T">The requested return type.</typeparam>
         /// <param name="path">Node path.</param>
         /// <param name="version">The requested version. For example: new VersionNumber(2, 0).</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A node as the provided derived type.</returns>
         public static async Task<T> LoadAsync<T>(string path, VersionNumber version, CancellationToken cancellationToken) where T : Node
         {
@@ -2076,7 +2076,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </code>
         /// </example>
         /// <param name="path">Node path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The latest accessible version of the <see cref="Node"/> that has the given path, or null.</returns>
         public static Task<Node> LoadNodeAsync(string path, CancellationToken cancellationToken)
         {
@@ -2115,7 +2115,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </example>
         /// <param name="path">Node path.</param>
         /// <param name="version">The requested version. For example: new VersionNumber(2, 0).</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The <see cref="Node"/> holds the data of the given version of the <see cref="Node"/> that has the given path.</returns>
         public static async Task<Node> LoadNodeAsync(string path, VersionNumber version, CancellationToken cancellationToken)
         {
@@ -2150,7 +2150,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </code>
         /// </example>
         /// <param name="nodeId">Node id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The latest version of the <see cref="Node"/> that has the given Id.</returns> 
         public static Task<Node> LoadNodeAsync(int nodeId, CancellationToken cancellationToken)
         {
@@ -2185,7 +2185,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </example>
         /// <param name="nodeId">Node id.</param>
         /// <param name="version">The requested version. For example: new VersionNumber(2, 0).</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The given version of the <see cref="Node"/> that has the given Id.</returns>
         public static async Task<Node> LoadNodeAsync(int nodeId, VersionNumber version, CancellationToken cancellationToken)
         {
@@ -2205,7 +2205,7 @@ namespace SenseNet.ContentRepository.Storage
         /// Loads a <see cref="Node"/> by the provided <see cref="NodeHead"/>.
         /// </summary>
         /// <param name="head">Node head.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static Task<Node> LoadNodeAsync(NodeHead head, CancellationToken cancellationToken)
         {
             return LoadNodeAsync(head, null, cancellationToken);
@@ -2286,7 +2286,7 @@ namespace SenseNet.ContentRepository.Storage
         /// </summary>
         /// <param name="head">Node head.</param>
         /// <param name="version">The requested version. For example: new VersionNumber(2, 0).</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<Node> LoadNodeAsync(NodeHead head, VersionNumber version, CancellationToken cancellationToken)
         {
             if (version == null)
@@ -2375,7 +2375,7 @@ namespace SenseNet.ContentRepository.Storage
         /// Loads a <see cref="Node"/> by the provided parameter that can be a path or an id as a string.
         /// </summary>
         /// <param name="idOrPath">Id (e.g. "42") or path (e.g. "/Root/System").</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static Task<Node> LoadNodeByIdOrPathAsync(string idOrPath, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(idOrPath))
@@ -2640,7 +2640,7 @@ namespace SenseNet.ContentRepository.Storage
         /// Loads a <see cref="Node"/> by the provided versionId.
         /// </summary>
         /// <param name="versionId">Version id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public static async Task<Node> LoadNodeByVersionIdAsync(int versionId, CancellationToken cancellationToken)
         {
             var head = await NodeHead.GetByVersionIdAsync(versionId, cancellationToken).ConfigureAwait(false);

--- a/src/Storage/Search/IIndexPopulator.cs
+++ b/src/Storage/Search/IIndexPopulator.cs
@@ -33,7 +33,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// <summary>
         /// Builds a brand new index.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="consoleWriter">TextWriter instance for writing progress.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task ClearAndPopulateAllAsync(CancellationToken cancellationToken, TextWriter consoleWriter = null);
@@ -43,7 +43,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// It does not notify other web servers and does not register activities.
         /// </summary>
         /// <param name="path">Subtree path.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="level">Index rebuild level. Default is <see cref="IndexRebuildLevel.IndexOnly"/>.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task RebuildIndexDirectlyAsync(string path, CancellationToken cancellationToken, IndexRebuildLevel level = IndexRebuildLevel.IndexOnly);
@@ -52,7 +52,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// </summary>
         /// <param name="path">The Path of the root node of the subtree.</param>
         /// <param name="nodeId">The Id of the root node of the subtree.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task AddTreeAsync(string path, int nodeId, CancellationToken cancellationToken);
         /// <summary>
@@ -71,7 +71,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// </summary>
         /// <param name="data">The snapshot recorded by the <see cref="BeginPopulateNode"/> method.</param>
         /// <param name="indexDocument">The index document that will be written into the index.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task CommitPopulateNodeAsync(object data, IndexDocumentData indexDocument, CancellationToken cancellationToken);
         /// <summary>
@@ -79,7 +79,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// </summary>
         /// <param name="data">The snapshot recorded by the <see cref="BeginPopulateNode"/> method.</param>
         /// <param name="indexDocument">The index document that will be written into the index.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task FinalizeTextExtractingAsync(object data, IndexDocumentData indexDocument, CancellationToken cancellationToken);
         /// <summary>
@@ -87,7 +87,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// </summary>
         /// <param name="path">Path of the deleted content.</param>
         /// <param name="nodeId">Id of the deleted content.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteTreeAsync(string path, int nodeId, CancellationToken cancellationToken);
 
@@ -96,7 +96,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// The idSet cannot be null.
         /// </summary>
         /// <param name="idSet">An array of subtree root ids to delete.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteForestAsync(IEnumerable<int> idSet, CancellationToken cancellationToken);
         /// <summary>
@@ -104,7 +104,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// The pathSet cannot be null.
         /// </summary>
         /// <param name="pathSet">An array of subtree root paths to delete.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         Task DeleteForestAsync(IEnumerable<string> pathSet, CancellationToken cancellationToken);
 
@@ -112,7 +112,7 @@ namespace SenseNet.ContentRepository.Search.Indexing
         /// Rebuilds the index of a node or a subtree.
         /// </summary>
         /// <param name="node">The root node of the subtree.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="recursive">True if the intention is to reindex the whole subtree.</param>
         /// <param name="rebuildLevel">Index rebuild level. Default is <see cref="IndexRebuildLevel.IndexOnly"/>.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>

--- a/src/Storage/Security/AccessTokenVault.cs
+++ b/src/Storage/Security/AccessTokenVault.cs
@@ -30,7 +30,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <summary>
         /// Deletes all AccessTokens even if they are still valid.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteAllAccessTokensAsync(CancellationToken cancellationToken)
         {
@@ -56,7 +56,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="userId">The id of the User that is the owner of the token.</param>
         /// <param name="timeout">The timeout of the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new AccessToken instance.</returns>
         public static Task<AccessToken> CreateTokenAsync(int userId, TimeSpan timeout,
             CancellationToken cancellationToken)
@@ -70,7 +70,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="userId">The id of the User that is the owner of the token.</param>
         /// <param name="timeout">The timeout of the token.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new AccessToken instance.</returns>
         public static Task<AccessToken> CreateTokenAsync(int userId, TimeSpan timeout, int contentId,
             CancellationToken cancellationToken)
@@ -85,7 +85,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="timeout">The timeout of the token.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
         /// <param name="feature">Any word that identifies the feature.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the new AccessToken instance.</returns>
         public static async Task<AccessToken> CreateTokenAsync(int userId, TimeSpan timeout, int contentId, string feature,
             CancellationToken cancellationToken)
@@ -126,7 +126,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="userId">The id of the User that is the owner of the token.</param>
         /// <param name="timeout">The timeout of the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps
         /// the existing or new AccessToken instance.</returns>
         public static Task<AccessToken> GetOrAddTokenAsync(int userId, TimeSpan timeout,
@@ -142,7 +142,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="userId">The id of the User that is the owner of the token.</param>
         /// <param name="timeout">The timeout of the token.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps
         /// the existing or new AccessToken instance.</returns>
         public static Task<AccessToken> GetOrAddTokenAsync(int userId, TimeSpan timeout, int contentId,
@@ -159,7 +159,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="timeout">The timeout of the token.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
         /// <param name="feature">Any word that identifies the feature.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps
         /// the existing or new AccessToken instance.</returns>
         public static async Task<AccessToken> GetOrAddTokenAsync(int userId, TimeSpan timeout, int contentId, string feature,
@@ -216,7 +216,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Gets the token by the specified value.
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the existing AccessToken or null.</returns>
         public static Task<AccessToken> GetTokenAsync(string tokenValue,
             CancellationToken cancellationToken)
@@ -229,7 +229,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the existing AccessToken or null.</returns>
         public static Task<AccessToken> GetTokenAsync(string tokenValue, int contentId,
             CancellationToken cancellationToken)
@@ -243,7 +243,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
         /// <param name="feature">Any word that identifies the feature.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps the existing AccessToken or null.</returns>
         public static Task<AccessToken> GetTokenAsync(string tokenValue, int contentId, string feature,
             CancellationToken cancellationToken)
@@ -264,7 +264,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Gets all tokens of the provided User.
         /// </summary>
         /// <param name="userId">The token owner ID.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps an AccessToken array.</returns>
         public static Task<AccessToken[]> GetAllTokensAsync(int userId, 
             CancellationToken cancellationToken)
@@ -289,7 +289,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Checks whether the specified token value exists and has not yet expired.
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>True if the token exists and is valid.</returns>
         public static Task<bool> TokenExistsAsync(string tokenValue, CancellationToken cancellationToken)
         {
@@ -301,7 +301,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and
         /// wraps True if the token exists and is valid.</returns>
         public static Task<bool> TokenExistsAsync(string tokenValue, int contentId, CancellationToken cancellationToken)
@@ -315,7 +315,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
         /// <param name="feature">Any word that identifies the feature.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and
         /// wraps True if the token exists and is valid.</returns>
         public static async Task<bool> TokenExistsAsync(string tokenValue, int contentId, string feature, CancellationToken cancellationToken)
@@ -341,7 +341,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// The 'contentId' or 'feature' parameters are necessary if the original token was emitted by these.
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="InvalidAccessTokenException"></exception>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task AssertTokenExistsAsync(string tokenValue, CancellationToken cancellationToken)
@@ -354,7 +354,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="InvalidAccessTokenException"></exception>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task AssertTokenExistsAsync(string tokenValue, int contentId,
@@ -369,7 +369,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// <param name="tokenValue">The token value.</param>
         /// <param name="contentId">The id of the Content that is associated with the token.</param>
         /// <param name="feature">Any word that identifies the feature.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="InvalidAccessTokenException"></exception>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static async Task AssertTokenExistsAsync(string tokenValue, int contentId, string feature,
@@ -396,7 +396,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// </summary>
         /// <param name="tokenValue">The value of the original token.</param>
         /// <param name="expirationDate">The new expiration date.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <exception cref="InvalidAccessTokenException"></exception>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task UpdateTokenAsync(string tokenValue, DateTime expirationDate,
@@ -417,7 +417,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Deletes the specified token regardless of expiration date.
         /// </summary>
         /// <param name="tokenValue">The value of the original token.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteTokenAsync(string tokenValue, CancellationToken cancellationToken)
         {
@@ -436,7 +436,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Deletes all tokens of the provided user regardless of expiration date.
         /// </summary>
         /// <param name="userId">The token owner ID.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteTokensByUserAsync(int userId, CancellationToken cancellationToken)
         {
@@ -455,7 +455,7 @@ namespace SenseNet.ContentRepository.Storage.Security
         /// Deletes the tokens associated with the specified contentId regardless of expiration date.
         /// </summary>
         /// <param name="contentId">The associated content id.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation.</returns>
         public static Task DeleteTokensByContentAsync(int contentId, CancellationToken cancellationToken)
         {

--- a/src/Storage/TreeLock.cs
+++ b/src/Storage/TreeLock.cs
@@ -50,7 +50,7 @@ namespace SenseNet.ContentRepository.Storage
         /// Locks one or more subtrees in the Content Repository. If a subtree is locked, no modifications (Save operations) can be made there.
         /// Use this method with a using statement to make sure that the lock is released when not needed anymore.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="paths">One or more Content Repository paths to be locked.</param>
         /// <exception cref="LockedTreeException">Thrown when any of the requested paths (or any of the parent containers) are already locked.</exception>
         /// <returns>A Task that represents the asynchronous operation and wraps the new tree lock
@@ -104,7 +104,7 @@ namespace SenseNet.ContentRepository.Storage
         /// <summary>
         /// Checks whether a subtree is locked. Used by save operations to make sure that it is OK to make modifications.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="paths">One or more Content Repository paths to check for locked state.</param>
         /// <exception cref="LockedTreeException">Thrown when any of the requested paths (or any of the parent containers) are already locked.</exception>
         /// <returns>A Task that represents the asynchronous operation.</returns>
@@ -148,7 +148,7 @@ namespace SenseNet.ContentRepository.Storage
         /// <summary>
         /// Gets all existing locks in the system.
         /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task that represents the asynchronous operation and wraps a lock id, path dictionary.</returns>
         public static Task<Dictionary<int, string>> GetAllLocksAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
The second sentence is removed from the following XML comment lines:
```
<param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
```
"Default value" indicates that the parameter is optional, which is misleading if the parameter is actually mandatory.
