### PR TITLE
Prevent role fields from throwing an exception

### DIFF
--- a/src/ContentRepository/Fields/AllRolesField.cs
+++ b/src/ContentRepository/Fields/AllRolesField.cs
@@ -19,10 +19,9 @@ namespace SenseNet.ContentRepository.Fields
 
         public override object GetData()
         {
-            return SecurityHandler.SecurityContext
-                .GetParentGroups(this.Content.Id, false)
-                .Select(Node.LoadNode)
-                .ToArray();
+            // this method will load only containers that the current user has permissions for
+            return Node.LoadNodes(SecurityHandler.SecurityContext
+                .GetParentGroups(this.Content.Id, false)).ToArray();
         }
     }
 }

--- a/src/ContentRepository/Fields/DirectRolesField.cs
+++ b/src/ContentRepository/Fields/DirectRolesField.cs
@@ -19,10 +19,9 @@ namespace SenseNet.ContentRepository.Fields
 
         public override object GetData()
         {
-            return SecurityHandler.SecurityContext
-                .GetParentGroups(this.Content.Id, true)
-                .Select(Node.LoadNode)
-                .ToArray();
+            // this method will load only containers that the current user has permissions for
+            return Node.LoadNodes(SecurityHandler.SecurityContext
+                .GetParentGroups(this.Content.Id, true)).ToArray();
         }
 
     }


### PR DESCRIPTION
Prevent role fields from throwing an exception if the caller does not have permissions for some of the roles.