### PR TITLE
Handle forms-encoded odata request body correctly.

### DIFF
--- a/src/OData/ODataMiddleware.cs
+++ b/src/OData/ODataMiddleware.cs
@@ -405,13 +405,23 @@ namespace SenseNet.OData
         {
             if (string.IsNullOrEmpty(models))
                 return null;
+
+            static bool IsJson(string postData)
+            {
+                if (string.IsNullOrEmpty(postData))
+                    return false;
+                return postData.StartsWith("{") && postData.EndsWith("}") ||
+                       postData.StartsWith("[{") && postData.EndsWith("}]");
+            }
             
+            // determine the starting and closing bracket type
             var firstChar = models.Last() == ']' ? '[' : '{';
             var p = models.IndexOf(firstChar);
             if (p > 0)
                 models = models.Substring(p);
 
-            if (!models.StartsWith("{") || !models.EndsWith("}"))
+            // if the data is formatted as a forms-encoded collection, convert it to json
+            if (!IsJson(models))
             {
                 var json = new StringBuilder("{");
                 var pairs = models.Split('&');

--- a/src/Tests/SenseNet.ODataTests/ODataOperationMethodTests.cs
+++ b/src/Tests/SenseNet.ODataTests/ODataOperationMethodTests.cs
@@ -1091,6 +1091,34 @@ namespace SenseNet.ODataTests
             Assert.AreEqual(JTokenType.Object, request["e"].Type);
         }
         [TestMethod]
+        public void OD_MBO_Request_SpecialChars()
+        {
+            var request = ODataMiddleware.ReadToJson("models=[{'a':'b=c&d=e'}]");
+
+            Assert.IsTrue(request.ContainsKey("a"), "Property 'a' not found.");
+            Assert.AreEqual(1, request.Count, "Incorrect number of child elements.");
+
+            Assert.AreEqual(JTokenType.String, request["a"].Type);
+            Assert.AreEqual("b=c&d=e", request["a"].Value<string>());
+
+            request = ODataMiddleware.ReadToJson("models=[{'a':'b=c&d=e&$f=g&#h=i'}]");
+            Assert.AreEqual(JTokenType.String, request["a"].Type);
+            Assert.AreEqual("b=c&d=e&$f=g&#h=i", request["a"].Value<string>());
+        }
+        [TestMethod]
+        public void OD_MBO_Request_FormsEncoded()
+        {
+            var request = ODataMiddleware.ReadToJson("a=b&c=d");
+
+            Assert.IsTrue(request.ContainsKey("a"), "Property 'a' not found.");
+            Assert.AreEqual(2, request.Count, "Incorrect number of child elements.");
+
+            Assert.AreEqual(JTokenType.String, request["a"].Type);
+            Assert.AreEqual("b", request["a"].Value<string>());
+            Assert.AreEqual("d", request["c"].Value<string>());
+        }
+
+        [TestMethod]
         public void OD_MBO_Request_Float()
         {
             var request = ODataMiddleware.ReadToJson("models=[{'a':4.2}]");


### PR DESCRIPTION
Do not try to parse a json body as a forms-encoded collection if it looks like a json text.