### PR TITLE
Consolidate middleware registration

### DIFF
--- a/src/OData/ODataExtensions.cs
+++ b/src/OData/ODataExtensions.cs
@@ -14,13 +14,17 @@ namespace SenseNet.Extensions.DependencyInjection
         /// if the request contains the odata.svc prefix.
         /// </summary>
         /// <param name="builder">IApplicationBuilder instance.</param>
-        /// <param name="buildAppBranch">Optional builder method. Use this when you want to add
+        /// <param name="buildAppBranchBefore">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline before the sensenet OData middleware.</param>
+        /// <param name="buildAppBranchAfter">Optional builder method. Use this when you want to add
         /// additional middleware in the pipeline after the sensenet OData middleware.</param>
         public static IApplicationBuilder UseSenseNetOdata(this IApplicationBuilder builder, 
-            Action<IApplicationBuilder> buildAppBranch = null)
+            Action<IApplicationBuilder> buildAppBranchBefore = null,
+            Action<IApplicationBuilder> buildAppBranchAfter = null)
         {
             // add OData middleware only if the request contains the appropriate prefix
-            builder.MapMiddlewareWhen<ODataMiddleware>("/odata.svc", buildAppBranch);
+            builder.MapMiddlewareWhen<ODataMiddleware>("/odata.svc", buildAppBranchBefore, 
+                buildAppBranchAfter, true);
 
             builder.UseOperationMethodExecutionPolicy(new VersioningOperationMethodPolicy());
 

--- a/src/Services.Core/MiddlewareExtensions.cs
+++ b/src/Services.Core/MiddlewareExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 // ReSharper disable once CheckNamespace
 namespace SenseNet.Extensions.DependencyInjection
@@ -11,29 +13,61 @@ namespace SenseNet.Extensions.DependencyInjection
         /// if the request contains the provided prefix.
         /// </summary>
         /// <param name="builder">IApplicationBuilder instance.</param>
-        /// <param name="pathSegmentStart">The url segment to match for (e.g. /myprefix).</param>
-        /// <param name="buildAppBranch">Optional builder method. Use this when you want to add
+        /// <param name="predicate">If this predicate returns true, the provided middleware will be added to the pipeline.</param>
+        /// <param name="buildAppBranchBefore">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline before the sensenet middleware.</param>
+        /// <param name="buildAppBranchAfter">Optional builder method. Use this when you want to add
         /// additional middleware in the pipeline after the sensenet middleware.</param>
+        /// <param name="terminateAppBranch">Whether to add a terminating middleware after
+        /// registering the provided middleware in case the condition is true. Default is true.</param>
         public static IApplicationBuilder MapMiddlewareWhen<T>(this IApplicationBuilder builder,
-            string pathSegmentStart, Action<IApplicationBuilder> buildAppBranch = null) where T: class
+            Func<HttpContext, bool> predicate, 
+            Action<IApplicationBuilder> buildAppBranchBefore = null,
+            Action<IApplicationBuilder> buildAppBranchAfter = null,
+            bool terminateAppBranch = false)
         {
             // add the middleware only if the request contains the appropriate prefix
-            builder.MapWhen(httpContext => httpContext.Request.Path.StartsWithSegments(pathSegmentStart),
-                appBranch =>
-                {
-                    appBranch.UseMiddleware<T>();
+            builder.MapWhen(predicate, appBranch =>
+            {
+                buildAppBranchBefore?.Invoke(appBranch);
 
-                    // Register a follow-up middleware defined by the caller or set a terminating, empty middleware.
-                    // If we do not do this, the system will try to set the status code which is not possible as
-                    // the request may have already been started by the middleware above.
+                appBranch.UseMiddleware<T>();
 
-                    if (buildAppBranch != null)
-                        buildAppBranch.Invoke(appBranch);
-                    else
-                        appBranch.Use((context, next) => System.Threading.Tasks.Task.CompletedTask);
-                });
+                // Register a follow-up middleware defined by the caller or set a terminating, empty middleware.
+                // If we do not do this, the system will try to set the status code which is not possible as
+                // the request may have already been started by the middleware above.
+
+                buildAppBranchAfter?.Invoke(appBranch);
+
+                if (terminateAppBranch)
+                    appBranch.Use((context, next) => Task.CompletedTask);
+            });
 
             return builder;
+        }
+
+        /// <summary>
+        /// Registers a sensenet middleware in the pipeline
+        /// if the request contains the provided prefix.
+        /// </summary>
+        /// <param name="builder">IApplicationBuilder instance.</param>
+        /// <param name="pathSegmentStart">The url segment to match for (e.g. /myprefix).</param>
+        /// <param name="buildAppBranchBefore">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline before the sensenet middleware.</param>
+        /// <param name="buildAppBranchAfter">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline after the sensenet middleware.</param>
+        /// <param name="terminateAppBranch">Whether to add a terminating middleware after
+        /// registering the provided middleware in case the condition is true. Default is true.</param>
+        public static IApplicationBuilder MapMiddlewareWhen<T>(this IApplicationBuilder builder,
+            string pathSegmentStart, 
+            Action<IApplicationBuilder> buildAppBranchBefore = null, 
+            Action<IApplicationBuilder> buildAppBranchAfter = null, 
+            bool terminateAppBranch = false)
+            where T : class
+        {
+            return MapMiddlewareWhen<T>(builder,
+                httpContext => httpContext.Request.Path.StartsWithSegments(pathSegmentStart), 
+                buildAppBranchBefore, buildAppBranchAfter, terminateAppBranch);
         }
     }
 }

--- a/src/Services.Core/Virtualization/VirtualizationExtensions.cs
+++ b/src/Services.Core/Virtualization/VirtualizationExtensions.cs
@@ -20,25 +20,17 @@ namespace SenseNet.Extensions.DependencyInjection
         /// Add this middleware after authentication/authorization middlewares.
         /// </summary>
         /// <param name="builder">IApplicationBuilder instance.</param>
-        /// <param name="buildAppBranch">Optional builder method. Use this when you want to add
+        /// <param name="buildAppBranchBefore">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline before the sensenet binary middleware.</param>
+        ///  <param name="buildAppBranchAfter">Optional builder method. Use this when you want to add
         /// additional middleware in the pipeline after the sensenet binary middleware.</param>
         public static IApplicationBuilder UseSenseNetFiles(this IApplicationBuilder builder,
-            Action<IApplicationBuilder> buildAppBranch = null)
+            Action<IApplicationBuilder> buildAppBranchBefore = null,
+            Action<IApplicationBuilder> buildAppBranchAfter = null)
         {
             // add binary middleware only if the request is recognized to be a binary request
-            builder.MapWhen(IsBinaryRequest, appBranch =>
-            {
-                appBranch.UseMiddleware<BinaryMiddleware>();
-
-                // Register a follow-up middleware defined by the caller or set a terminating, empty middleware.
-                // If we do not do this, the system will try to set the status code which is not possible as
-                // the request has already been started by our middleware above.
-
-                if (buildAppBranch != null)
-                    buildAppBranch.Invoke(appBranch);
-                else
-                    appBranch.Use((context, next) => Task.CompletedTask);
-            });
+            builder.MapMiddlewareWhen<BinaryMiddleware>(IsBinaryRequest, buildAppBranchBefore,
+                buildAppBranchAfter, true);
 
             return builder;
         }

--- a/src/Services.Wopi/WopiExtensions.cs
+++ b/src/Services.Wopi/WopiExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using SenseNet.Services.Core;
 using SenseNet.Services.Wopi;
 using System;
 
@@ -13,13 +12,17 @@ namespace SenseNet.Extensions.DependencyInjection
         /// if the request contains the wopi prefix.
         /// </summary>
         /// <param name="builder">IApplicationBuilder instance.</param>
-        /// <param name="buildAppBranch">Optional builder method. Use this when you want to add
+        /// <param name="buildAppBranchBefore">Optional builder method. Use this when you want to add
+        /// additional middleware in the pipeline before the sensenet WOPI middleware.</param>
+        /// <param name="buildAppBranchAfter">Optional builder method. Use this when you want to add
         /// additional middleware in the pipeline after the sensenet WOPI middleware.</param>
         public static IApplicationBuilder UseSenseNetWopi(this IApplicationBuilder builder,
-            Action<IApplicationBuilder> buildAppBranch = null)
+            Action<IApplicationBuilder> buildAppBranchBefore = null,
+            Action<IApplicationBuilder> buildAppBranchAfter = null)
         {
             // add WOPI middleware if the request contains a prefix
-            builder.MapMiddlewareWhen<WopiMiddleware>("/wopi", buildAppBranch);
+            builder.MapMiddlewareWhen<WopiMiddleware>("/wopi", buildAppBranchBefore, 
+                buildAppBranchAfter, true);
 
             // add the necessary execution policies
             builder.UseOperationMethodExecutionPolicy(new WopiOpenViewMethodPolicy())


### PR DESCRIPTION
Consolidate middleware registration and add before-after builder methods.

From now on all conditional middlewares (OData, binary, wopi) call the same map method for registering before and after app branches.