### PR TITLE
Fix order of fields in webhook ctd and hide InvalidFields

### DIFF
--- a/src/WebHooks/import/System/Schema/ContentTypes/WebHookSubscriptionCtd.xml
+++ b/src/WebHooks/import/System/Schema/ContentTypes/WebHookSubscriptionCtd.xml
@@ -46,7 +46,7 @@
       <DisplayName>$Ctd-WebHookSubscription,WebHookFilter-DisplayName</DisplayName>
       <Description>$Ctd-WebHookSubscription,WebHookFilter-Description</Description>
       <Configuration>
-        <FieldIndex>40</FieldIndex>
+        <FieldIndex>50</FieldIndex>
         <ControlHint>sn:WebhookFilter</ControlHint>
       </Configuration>
     </Field>
@@ -54,7 +54,7 @@
       <DisplayName>$Ctd-WebHookSubscription,WebHookHeaders-DisplayName</DisplayName>
       <Description>$Ctd-WebHookSubscription,WebHookHeaders-Description</Description>
       <Configuration>
-        <FieldIndex>30</FieldIndex>
+        <FieldIndex>40</FieldIndex>
         <ControlHint>sn:WebhookHeaders</ControlHint>
       </Configuration>
     </Field>
@@ -62,7 +62,7 @@
       <DisplayName>$Ctd-WebHookSubscription,Enabled-DisplayName</DisplayName>
       <Description>$Ctd-WebHookSubscription,Enabled-Description</Description>
       <Configuration>
-        <FieldIndex>20</FieldIndex>
+        <FieldIndex>90</FieldIndex>
         <DefaultValue>true</DefaultValue>
         <VisibleBrowse>Show</VisibleBrowse>
         <VisibleEdit>Show</VisibleEdit>
@@ -71,7 +71,7 @@
     </Field>
     <Field name="IsValid" type="Boolean">
       <Configuration>
-        <FieldIndex>25</FieldIndex>
+        <FieldIndex>30</FieldIndex>
         <ReadOnly>true</ReadOnly>
         <VisibleBrowse>Show</VisibleBrowse>
         <VisibleEdit>Hide</VisibleEdit>
@@ -80,15 +80,17 @@
     </Field>
     <Field name="InvalidFields" type="ShortText">
       <Configuration>
-        <FieldIndex>27</FieldIndex>
         <ReadOnly>true</ReadOnly>
+         <VisibleBrowse>Hide</VisibleBrowse>
+        <VisibleEdit>Hide</VisibleEdit>
+        <VisibleNew>Hide</VisibleNew>
       </Configuration>
     </Field>
     <Field name="SuccessfulCalls" type="Integer">
       <DisplayName>$Ctd-WebHookSubscription,SuccessfulCalls-DisplayName</DisplayName>
       <Description>$Ctd-WebHookSubscription,SuccessfulCalls-Description</Description>
       <Configuration>
-        <FieldIndex>10</FieldIndex>
+        <FieldIndex>20</FieldIndex>
         <VisibleBrowse>Show</VisibleBrowse>
         <VisibleEdit>Show</VisibleEdit>
         <VisibleNew>Hide</VisibleNew>
@@ -153,7 +155,7 @@
     </Field>
     <Field name="WebHookPayload" type="LongText">
       <Configuration>
-        <FieldIndex>0</FieldIndex>
+        <FieldIndex>10</FieldIndex>
         <ControlHint>sn:WebhookPayload</ControlHint>
         <VisibleBrowse>Show</VisibleBrowse>
         <VisibleEdit>Show</VisibleEdit>


### PR DESCRIPTION
Fix order of fields in webhook ctd and hide InvalidFields