### PR TITLE
Change ctd Icon names

### DIFF
--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/BinaryFieldSettingCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/BinaryFieldSettingCtd.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType name='BinaryFieldSetting' parentType='FieldSettingContent' handler='SenseNet.ContentRepository.Schema.FieldSettingContent' xmlns='http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition'>
   <DisplayName>$Ctd-BinaryFieldSetting,DisplayName</DisplayName>
-  <Icon>File</Icon>
+  <Icon>FieldSetting</Icon>
   <Fields />
 </ContentType>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ContentLinkCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ContentLinkCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="ContentLink" parentType="GenericContent" handler="SenseNet.ContentRepository.ContentLink" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-ContentLink,DisplayName</DisplayName>
 	<Description>$Ctd-ContentLink,Description</Description>
-	<Icon>Folder</Icon>
+	<Icon>ContentLink</Icon>
 	<Fields>
     <Field name="Name" type="ShortText">
       <Configuration>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/DocumentLibraryCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/DocumentLibraryCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="DocumentLibrary" parentType="Library" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-DocumentLibrary,DisplayName</DisplayName>
   <Description>$Ctd-DocumentLibrary,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>DocumentLibrary</Icon>
   <AllowedChildTypes>
     Folder,File
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/EmailCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/EmailCtd.xml
@@ -1,7 +1,7 @@
 <ContentType name="Email" parentType="Folder" handler="SenseNet.ContentRepository.Folder" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Email,DisplayName</DisplayName>
   <Description>$Ctd-Email,Description</Description>
-  <Icon>Document</Icon>
+  <Icon>Email</Icon>
   <AllowIncrementalNaming>true</AllowIncrementalNaming>
   <AllowedChildTypes>
     File

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/EventListCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/EventListCtd.xml
@@ -1,7 +1,7 @@
 <ContentType name="EventList" parentType="ItemList" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-EventList,DisplayName</DisplayName>
   <Description>$Ctd-EventList,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>EventList</Icon>
   <AllowedChildTypes>CalendarEvent</AllowedChildTypes>
   <Fields>
     <Field name="DisplayName" type="ShortText">

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ExecutableFileCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ExecutableFileCtd.xml
@@ -2,6 +2,6 @@
 <ContentType name="ExecutableFile" parentType="File" handler="SenseNet.ContentRepository.File" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-ExecutableFile,DisplayName</DisplayName>
   <Description>$Ctd-ExecutableFile,Description</Description>
-  <Icon>Application</Icon>
+  <Icon>ExecutableFile</Icon>
   <Preview>false</Preview>
 </ContentType>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ImageLibraryCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ImageLibraryCtd.xml
@@ -1,7 +1,7 @@
 ﻿<ContentType name="ImageLibrary" parentType="Library" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-ImageLibrary,DisplayName</DisplayName>
   <Description>$Ctd-ImageLibrary,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>ImageLibrary</Icon>
   <AllowedChildTypes>
     Folder,Image
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/LibraryCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/LibraryCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Library" parentType="ContentList" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Library,DisplayName</DisplayName>
   <Description>$Ctd-Library,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>Library</Icon>
   <Fields>
     <Field name="InheritableVersioningMode" type="InheritableVersioningMode">
       <DisplayName>$Ctd-GenericContent,InheritableVersioningMode-DisplayName</DisplayName>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/LinkListCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/LinkListCtd.xml
@@ -1,7 +1,7 @@
 <ContentType name="LinkList" parentType="ItemList" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-LinkList,DisplayName</DisplayName>
   <Description>$Ctd-LinkList,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>LinkList</Icon>
   <AllowedChildTypes>Link</AllowedChildTypes>
   <Fields>
   <Field name="DisplayName" type="ShortText">

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/MemoCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/MemoCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Memo" parentType="ListItem" handler="SenseNet.ContentRepository.GenericContent" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Memo,DisplayName</DisplayName>
   <Description>$Ctd-Memo,Description</Description>
-  <Icon>Document</Icon>
+  <Icon>Memo</Icon>
   <AllowIncrementalNaming>true</AllowIncrementalNaming>
   <Fields>
     <Field name="Description" type="LongText">

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/MemoList.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/MemoList.xml
@@ -2,7 +2,7 @@
 <ContentType name="MemoList" parentType="ItemList" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-MemoList,DisplayName</DisplayName>
   <Description>$Ctd-MemoList,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>MemoList</Icon>
   <AllowedChildTypes>
     Memo
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/NullFieldSettingCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/NullFieldSettingCtd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ContentType name="NullFieldSetting" parentType="FieldSettingContent" handler="SenseNet.ContentRepository.Schema.FieldSettingContent" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-NullFieldSetting,DisplayName</DisplayName>
-  <Icon>File</Icon>
+  <Icon>FieldSetting</Icon>
   <Fields />
 </ContentType>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/PermissionChoiceFieldSettingCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/PermissionChoiceFieldSettingCtd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ContentType name="PermissionChoiceFieldSetting" parentType="ChoiceFieldSetting" handler="SenseNet.ContentRepository.Schema.FieldSettingContent" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-PermissionChoiceFieldSetting,DisplayName</DisplayName>
-  <Icon>File</Icon>
+  <Icon>FieldSetting</Icon>
   <Fields />
 </ContentType>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ProfilesCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ProfilesCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Profiles" parentType="Folder" handler="SenseNet.ContentRepository.Folder" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Profiles,DisplayName</DisplayName>
   <Description>$Ctd-Profiles,Description</Description>
-  <Icon>Folder</Icon>
+  <Icon>Profiles</Icon>
   <AllowedChildTypes>
     ProfileDomain
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ResourcesCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/ResourcesCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Resources" parentType="SystemFolder" handler="SenseNet.ContentRepository.SystemFolder" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Resources,DisplayName</DisplayName>
   <Description>$Ctd-Resources,Description</Description>
-  <Icon>Folder</Icon>
+  <Icon>Resources</Icon>
   <AllowedChildTypes>
     Resource
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SitesCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SitesCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Sites" parentType="Folder" handler="SenseNet.ContentRepository.Folder" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Sites,DisplayName</DisplayName>
   <Description>$Ctd-Sites,Description</Description>
-  <Icon>Site</Icon>
+  <Icon>Sites</Icon>
   <AllowedChildTypes>
     Site
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SystemFileCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SystemFileCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="SystemFile" parentType="File" handler="SenseNet.ContentRepository.File" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-SystemFile,DisplayName</DisplayName>
   <Description>$Ctd-SystemFile,Description</Description>
-  <Icon>File</Icon>
+  <Icon>SystemFile</Icon>
   <Fields>
     <Field name="Watermark" type="ShortText">
       <Configuration>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SystemFolderCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/SystemFolderCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="SystemFolder" parentType="Folder" handler="SenseNet.ContentRepository.SystemFolder" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-SystemFolder,DisplayName</DisplayName>
   <Description>$Ctd-SystemFolder,Description</Description>
-  <Icon>Folder</Icon>
+  <Icon>SystemFolder</Icon>
   <Fields>
   <Field name="DisplayName" type="ShortText">
     <DisplayName>$Ctd-SystemFolder,DisplayName-DisplayName</DisplayName>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TaskCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TaskCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="Task" parentType="ListItem" handler="SenseNet.ContentRepository.Task" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-Task,DisplayName</DisplayName>
   <Description>$Ctd-Task,Description</Description>
-  <Icon>FormItem</Icon>
+  <Icon>Task</Icon>
   <Fields>
     <Field name="Name" type="ShortText">
       <Configuration>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TaskList.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TaskList.xml
@@ -2,7 +2,7 @@
 <ContentType name="TaskList" parentType="ItemList" handler="SenseNet.ContentRepository.ContentList" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-TaskList,DisplayName</DisplayName>
   <Description>$Ctd-TaskList,Description</Description>
-  <Icon>ContentList</Icon>
+  <Icon>TaskList</Icon>
   <AllowedChildTypes>
     Task,ApprovalWorkflowTask,ExpenseClaimWorkflowTask
   </AllowedChildTypes>

--- a/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TrashBagCtd.xml
+++ b/src/nuget/snadmin/install-services/import/System/Schema/ContentTypes/TrashBagCtd.xml
@@ -2,7 +2,7 @@
 <ContentType name="TrashBag" parentType="Folder" handler="SenseNet.ContentRepository.TrashBag" xmlns="http://schemas.sensenet.com/SenseNet/ContentRepository/ContentTypeDefinition">
   <DisplayName>$Ctd-TrashBag,DisplayName</DisplayName>
   <Description>$Ctd-TrashBag,Description</Description>
-  <Icon>Folder</Icon>
+  <Icon>TrashBag</Icon>
   <AllowIncrementalNaming>true</AllowIncrementalNaming>
   <Fields>
     <Field name="DisplayName" type="ShortText">


### PR DESCRIPTION
Some of the old ctd's had a common Icon name and we had to differenciate by type name in the client code overiding the actul Icon of the type.