### PR TITLE
Fix failed tests

### DIFF
--- a/src/Tests/SenseNet.Services.Core.Tests/AuthenticationTests.cs
+++ b/src/Tests/SenseNet.Services.Core.Tests/AuthenticationTests.cs
@@ -33,8 +33,8 @@ namespace SenseNet.Services.Core.Tests
                 var user = await IdentityOperations.CreateLocalUser(root, context, userName, userName, userName + "@example.com");
 
                 // check if the user can log in
-                dynamic result = IdentityOperations.ValidateCredentials(root, context, "public\\" + userName, userName);
-                Assert.AreEqual(user.Id, result.id);
+                var result = IdentityOperations.ValidateCredentials(root, context, "public\\" + userName, userName);
+                Assert.AreEqual(user.Id, result.Id);
 
                 // ACTION: disable the user
                 user["Enabled"] = false;


### PR DESCRIPTION
Fixed tests:
- **OD_GET_Entity_Table**: avoid array/dictionary indexing errors when the length of the $select clause is not equal to the cell count.
- **Authentication_Validate_Disabled_CSrv**: use a typed object instead of a dynamic one.
