### PR TITLE
Fix/odata publicadmin permissions

### DIFF
--- a/src/ContentRepository/ApplicationModel/N.cs
+++ b/src/ContentRepository/ApplicationModel/N.cs
@@ -34,6 +34,7 @@ namespace SenseNet.ApplicationModel
         public static class R
         {
             public const string Administrators = "/Root/IMS/BuiltIn/Portal/Administrators";
+            public const string PublicAdministrators = "/Root/IMS/Public/Administrators";
             public const string Developers = "/Root/IMS/BuiltIn/Portal/Developers";
             public const string Everyone = "/Root/IMS/BuiltIn/Portal/Everyone";
             public const string IdentifiedUsers = "/Root/IMS/BuiltIn/Portal/IdentifiedUsers";

--- a/src/ContentRepository/Content.cs
+++ b/src/ContentRepository/Content.cs
@@ -149,7 +149,7 @@ namespace SenseNet.ContentRepository
             /// <param name="rebuildLevel">The algorithm selector. Value can be <value>IndexOnly</value> or <value>DatabaseAndIndex</value>. Default: <value>IndexOnly</value></param>
             [ODataAction]
             [ContentTypes(N.CT.GenericContent, N.CT.ContentType)]
-            [AllowedRoles(N.R.Administrators, N.R.Developers)]
+            [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
             [RequiredPermissions(N.P.Save)]
             public static void RebuildIndex(Content content, bool recursive, IndexRebuildLevel rebuildLevel)
             {
@@ -162,7 +162,7 @@ namespace SenseNet.ContentRepository
             /// <param name="content">The content provided by the infrastructure.</param>
             [ODataAction]
             [ContentTypes(N.CT.GenericContent, N.CT.ContentType)]
-            [AllowedRoles(N.R.Administrators, N.R.Developers)]
+            [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
             public static void RebuildIndexSubtree(Content content)
             {
                 content.RebuildIndex(true, IndexRebuildLevel.DatabaseAndIndex);
@@ -174,7 +174,7 @@ namespace SenseNet.ContentRepository
             /// <param name="content">The content provided by the infrastructure.</param>
             [ODataAction]
             [ContentTypes(N.CT.GenericContent, N.CT.ContentType)]
-            [AllowedRoles(N.R.Administrators, N.R.Developers)]
+            [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
             public static void RefreshIndexSubtree(Content content)
             {
                 content.RebuildIndex(true, IndexRebuildLevel.IndexOnly);
@@ -190,7 +190,7 @@ namespace SenseNet.ContentRepository
             /// <param name="content">The content provided by the infrastructure.</param>
             [ODataAction]
             [ContentTypes(N.CT.PortalRoot)]
-            [AllowedRoles(N.R.Administrators, N.R.Developers)]
+            [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
             public static async System.Threading.Tasks.Task RefreshIndexAndCleanActivities(Content content, HttpContext context)
             {
                 var logger = context.RequestServices.GetService<ILogger<Content>>();

--- a/src/ContentRepository/RepositoryTools.cs
+++ b/src/ContentRepository/RepositoryTools.cs
@@ -331,7 +331,7 @@ namespace SenseNet.ContentRepository
         /// <param name="root"></param>
         /// <returns>A dictionary where the ContentType name is the key and a path list is the value.</returns>
         [ODataFunction]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static Dictionary<string, List<string>> CheckAllowedChildTypesOfFolders(Content root)
         {
             var result = new Dictionary<string, List<string>>();
@@ -454,7 +454,7 @@ namespace SenseNet.ContentRepository
         /// <param name="root"></param>
         /// <returns>Path list.</returns>
         [ODataFunction]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static IEnumerable<string> MissingExplicitEntriesOfVisitorComparedToEveryone(Content root)
         {
             var result = new List<string>();
@@ -749,7 +749,7 @@ namespace SenseNet.ContentRepository
         /// <returns></returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static IndexProperties GetIndexProperties(Content content)
         {
             var engine = Providers.Instance.SearchEngine.IndexingEngine;
@@ -792,7 +792,7 @@ namespace SenseNet.ContentRepository
         /// <returns>The whole raw index.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async STT.Task GetWholeInvertedIndex(Content content, HttpContext httpContext)
         {
             var httpResponse = httpContext.Response;
@@ -861,7 +861,7 @@ namespace SenseNet.ContentRepository
         /// <returns>Key-value pairs of the term and a sorted documentId list.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async STT.Task<IDictionary<string, object>> GetInvertedIndex(Content content, HttpContext httpContext, string fieldName)
         {
             var engine = Providers.Instance.SearchEngine.IndexingEngine;
@@ -905,7 +905,7 @@ namespace SenseNet.ContentRepository
         /// <param name="versionId">Optional versionId if it is different from the versionId of the requested resource.</param>
         [ODataFunction]
         [ContentTypes(N.CT.GenericContent, N.CT.ContentType)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static IDictionary<string, object> GetIndexDocument(Content content, int versionId = 0)
         {
             if (versionId == 0)
@@ -958,7 +958,7 @@ namespace SenseNet.ContentRepository
         /// <param name="documentId">The documentId from the inverted index.</param>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static IDictionary<string, object> GetIndexDocumentByDocumentId(Content content, int documentId)
         {
             var engine = Providers.Instance.SearchEngine.IndexingEngine;
@@ -1148,7 +1148,7 @@ namespace SenseNet.ContentRepository
         /// <returns>A <see cref="SenseNet.Security.Messaging.SecurityActivityHistory"/> instance.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static SenseNet.Security.Messaging.SecurityActivityHistory GetRecentSecurityActivities(Content content)
         {
             return Providers.Instance.SecurityHandler.SecurityContext.GetRecentActivities();
@@ -1204,7 +1204,7 @@ namespace SenseNet.ContentRepository
         /// <returns>An <see cref="IndexingActivityHistory"/> instance.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static IndexingActivityHistory GetRecentIndexingActivities(Content content)
         {
             return ((IndexManager)Providers.Instance.IndexManager).DistributedIndexingActivityQueue.GetIndexingActivityHistory();

--- a/src/OData/IO/ImporterActions.cs
+++ b/src/OData/IO/ImporterActions.cs
@@ -52,7 +52,7 @@ namespace SenseNet.OData.IO
         /// and the postponed references or permission settings.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static object Import(Content content, string path, object data)
         {
             var jData = data as JObject;

--- a/src/Services.Core/Diagnostics/StatisticsController.cs
+++ b/src/Services.Core/Diagnostics/StatisticsController.cs
@@ -231,7 +231,7 @@ namespace SenseNet.Services.Core.Diagnostics
         /// <returns>A list of api usage records.</returns>
         [ODataFunction(operationName: "GetApiUsageList")]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<IEnumerable<ApiUsageListItemViewModel>> GetApiUsageList(Content content, HttpContext httpContext,
           DateTime? maxTime = null, int count = 10)
         {
@@ -257,7 +257,7 @@ namespace SenseNet.Services.Core.Diagnostics
         /// <returns>An API usage statistical data containing start and end dates and count of records.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static Task<object> GetApiUsagePeriods(Content content, HttpContext httpContext,
             TimeWindow? timeWindow = null)
         {
@@ -331,7 +331,7 @@ namespace SenseNet.Services.Core.Diagnostics
         /// <returns>API usage data containing time window information and a list of aggregated data points.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<object> GetApiUsagePeriod(Content content, HttpContext httpContext,
             TimeWindow? timeWindow = null, DateTime? time = null)
         {
@@ -358,7 +358,7 @@ namespace SenseNet.Services.Core.Diagnostics
         /// <returns>Database usage data containing time window information and a list of aggregated data points.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<object> GeDatabaseUsagePeriod(Content content, HttpContext httpContext,
             TimeWindow? timeWindow = null, DateTime? time = null)
         {

--- a/src/Services.Core/Operations/ApiKeyOperations.cs
+++ b/src/Services.Core/Operations/ApiKeyOperations.cs
@@ -79,7 +79,7 @@ namespace SenseNet.Services.Core.Operations
         /// <returns>An empty result.</returns>
         [ODataAction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static System.Threading.Tasks.Task DeleteApiKeys(Content content, HttpContext context)
         {
             var akm = context.RequestServices.GetRequiredService<IApiKeyManager>();
@@ -94,7 +94,7 @@ namespace SenseNet.Services.Core.Operations
         /// <returns>An empty result.</returns>
         [ODataAction(OperationName = "DeleteApiKeys")]
         [ContentTypes(N.CT.User)]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static System.Threading.Tasks.Task DeleteApiKeysByUser(Content content, HttpContext context)
         {
             var akm = context.RequestServices.GetRequiredService<IApiKeyManager>();

--- a/src/Services.Core/Operations/ClientStoreOperations.cs
+++ b/src/Services.Core/Operations/ClientStoreOperations.cs
@@ -22,7 +22,7 @@ namespace SenseNet.Services.Core.Operations
         /// <returns>A result object containing an array of clients.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static async Task<object> GetClientsForRepository(Content content, HttpContext context)
         {
             var clientStore = context.RequestServices.GetRequiredService<IClientManager>();
@@ -46,7 +46,7 @@ namespace SenseNet.Services.Core.Operations
         /// <returns>A result object containing an array of clients.</returns>
         [ODataFunction("GetClients")]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static async Task<object> GetClients(Content content, HttpContext context)
         {
             // Only administrators are allowed to get all types of clients. Regular

--- a/src/Services.Core/Operations/DiagnosticOperations.cs
+++ b/src/Services.Core/Operations/DiagnosticOperations.cs
@@ -79,7 +79,7 @@ namespace SenseNet.Services.Core.Operations
         /// <returns>A <see cref="RepositoryVersionView"/> instance containing releases, packages, components, assemblies.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<RepositoryVersionView> GetVersionInfo(Content content, HttpContext httpContext)
         {
             var componentStore = httpContext.RequestServices.GetService<ILatestComponentStore>();
@@ -126,7 +126,7 @@ namespace SenseNet.Services.Core.Operations
         /// and version count information.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<DatabaseUsage> GetDatabaseUsage(Content content, HttpContext httpContext, bool force = false)
         {
             var dbUsageHandler = httpContext.RequestServices.GetService<IDatabaseUsageHandler>();

--- a/src/Tests/SenseNet.Services.Core.Tests/ClientStoreTests.cs
+++ b/src/Tests/SenseNet.Services.Core.Tests/ClientStoreTests.cs
@@ -1,0 +1,522 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SenseNet.Tests.Core;
+using System;
+using System.Linq;
+using System.Threading;
+using SenseNet.ContentRepository;
+using SenseNet.ContentRepository.Security.Clients;
+using SenseNet.ContentRepository.Storage;
+using SenseNet.Services.Core.Operations;
+using Task = System.Threading.Tasks.Task;
+using Microsoft.AspNetCore.Http;
+using SenseNet.Configuration;
+using SenseNet.ContentRepository.Storage.Security;
+
+namespace SenseNet.Services.Core.Tests
+{
+    [TestClass]
+    public class ClientStoreTests : TestBase
+    {
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_GetClients_Admin()
+        {
+            return ClientStoreTest(async (context, _) =>
+            {
+                dynamic result = await ClientStoreOperations.GetClients(null, context);
+                var clients = (Client[])result.clients;
+
+                // all clients are accessible
+                Assert.AreEqual(5, clients.Length);
+                Assert.AreEqual(1, clients.Count(c => 
+                    c.UserName == "builtin\\admin" && c.Type == ClientType.InternalClient));
+
+                result = await ClientStoreOperations.GetClientsForRepository(null, context);
+                clients = (Client[])result.clients;
+
+                // only external clients are returned
+                Assert.AreEqual(4, clients.Length);
+                Assert.AreEqual(0, clients.Count(c => ClientType.AllInternal.HasFlag(c.Type)));
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_GetClients_PublicAdmin()
+        {
+            return ClientStoreTestForPublicAdmin(async (context, _) =>
+            {
+                dynamic result = await ClientStoreOperations.GetClients(null, context);
+                var clients = (Client[])result.clients;
+
+                // only 3 are accessible
+                Assert.AreEqual(3, clients.Length);
+                Assert.AreEqual(0, clients.Count(c =>
+                    c.UserName == "builtin\\admin" && c.Type == ClientType.InternalClient));
+                Assert.AreEqual(1, clients.Count(c =>
+                    c.UserName == "public\\user1" && c.Type == ClientType.ExternalClient));
+                Assert.AreEqual(1, clients.Count(c =>
+                    c.UserName == "builtin\\publicadmin" && c.Type == ClientType.ExternalClient));
+                Assert.AreEqual(0, clients.Count(c =>
+                    c.UserName == "domain2\\user2" && c.Type == ClientType.ExternalClient));
+
+                result = await ClientStoreOperations.GetClientsForRepository(null, context);
+                clients = (Client[])result.clients;
+
+                // only 3 are accessible
+                Assert.AreEqual(3, clients.Length);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_GetClients_RegularUser()
+        {
+            // This test does not take into account that currently clients cannot
+            // invoke these methods without being at least public admins.
+
+            return ClientStoreTestForRegularUser(async (context, _) =>
+            {
+                dynamic result = await ClientStoreOperations.GetClients(null, context);
+                var clients = (Client[])result.clients;
+
+                // only 3 are accessible
+                Assert.AreEqual(2, clients.Length);
+                Assert.AreEqual(0, clients.Count(c =>
+                    c.UserName == "builtin\\admin" && c.Type == ClientType.InternalClient));
+                Assert.AreEqual(0, clients.Count(c =>
+                    c.UserName == "public\\user1" && c.Type == ClientType.ExternalClient));
+                Assert.AreEqual(0, clients.Count(c =>
+                    c.UserName == "builtin\\publicadmin" && c.Type == ClientType.ExternalClient));
+                Assert.AreEqual(1, clients.Count(c =>
+                    c.UserName == "domain2\\user2" && c.Type == ClientType.ExternalClient));
+            });
+        }
+
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateClient_Admin()
+        {
+            return ClientStoreTest(async (context, _) =>
+            {
+                var client = await ClientStoreOperations.CreateClient(null, context, "admin1",
+                    ClientType.InternalClient.ToString());
+
+                // check default user
+                Assert.AreEqual("builtin\\admin", client.UserName);
+
+                client = await ClientStoreOperations.CreateClient(null, context, "admin2",
+                    ClientType.ExternalSpa.ToString(), "not required");
+
+                // check that username is ignored for this type of client
+                Assert.AreEqual(null, client.UserName);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateClient_PublicAdmin()
+        {
+            return ClientStoreTestForPublicAdmin(async (context, _) =>
+            {
+                var client = await ClientStoreOperations.CreateClient(null, context, "admin1",
+                    ClientType.ExternalClient.ToString());
+
+                // check default user
+                Assert.AreEqual("builtin\\publicadmin", client.UserName);
+
+                client = await ClientStoreOperations.CreateClient(null, context, "admin2",
+                    ClientType.ExternalClient.ToString(), "public\\user1");
+
+                // check custom user
+                Assert.AreEqual("public\\user1", client.UserName);
+
+                var thrown = false;
+
+                try
+                {
+                    // internal client is not allowed
+                    await ClientStoreOperations.CreateClient(null, context, "admin1",
+                        ClientType.InternalClient.ToString());
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+
+                thrown = false;
+
+                try
+                {
+                    // not accessible user
+                    await ClientStoreOperations.CreateClient(null, context, "admin1",
+                        ClientType.ExternalClient.ToString(), "domain2\\user2");
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateClient_RegularUser()
+        {
+            return ClientStoreTestForRegularUser(async (context, _) =>
+            {
+                var client = await ClientStoreOperations.CreateClient(null, context, "admin1",
+                        ClientType.ExternalClient.ToString());
+
+                // check default user: the current non-admin user, who is not a member of the public admin group
+                Assert.AreEqual("domain2\\user2", client.UserName);
+
+                client = await ClientStoreOperations.CreateClient(null, context, "admin2",
+                    ClientType.ExternalClient.ToString(), "domain2\\user2");
+
+                // check custom user
+                Assert.AreEqual("domain2\\user2", client.UserName);
+
+                var thrown = false;
+
+                try
+                {
+                    // internal client is not allowed
+                    await ClientStoreOperations.CreateClient(null, context, "admin1",
+                        ClientType.InternalClient.ToString());
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+
+                thrown = false;
+
+                try
+                {
+                    // not accessible user
+                    await ClientStoreOperations.CreateClient(null, context, "admin1",
+                        ClientType.ExternalClient.ToString(), "public\\user1");
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateSecret_Admin()
+        {
+            return ClientStoreTest(async (context, _) =>
+            {
+                var secret = await ClientStoreOperations.CreateSecret(null, context, "c1");
+
+                Assert.IsNotNull(secret.Value);
+
+                var thrown = false;
+
+                try
+                {
+                    // SPA client: no secret is allowed
+                    await ClientStoreOperations.CreateSecret(null, context, "c2");
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateSecret_PublicAdmin()
+        {
+            return ClientStoreTestForPublicAdmin(async (context, _) =>
+            {
+                // client for the public admin user: OK
+                var secret = await ClientStoreOperations.CreateSecret(null, context, "c3");
+                Assert.IsNotNull(secret.Value);
+
+                // client for another public admin user: OK
+                secret = await ClientStoreOperations.CreateSecret(null, context, "c4");
+                Assert.IsNotNull(secret.Value);
+
+                var thrown = false;
+
+                try
+                {
+                    // client for a not accessible user: NOT OK
+                    await ClientStoreOperations.CreateSecret(null, context, "c5");
+                }
+                catch (SenseNetSecurityException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_CreateSecret_RegularUser()
+        {
+            return ClientStoreTestForRegularUser(async (context, _) =>
+            {
+                // client for themselves: OK
+                var secret = await ClientStoreOperations.CreateSecret(null, context, "c5");
+                Assert.IsNotNull(secret.Value);
+
+                var thrown = false;
+
+                try
+                {
+                    // client for a not accessible user: NOT OK
+                    await ClientStoreOperations.CreateSecret(null, context, "c4");
+                }
+                catch (SenseNetSecurityException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_DeleteClient_Admin()
+        {
+            return ClientStoreTest(async (context, clientStore) =>
+            {
+                var client = await clientStore.GetClientAsync("x", "c1");
+                Assert.IsNotNull(client);
+
+                await ClientStoreOperations.DeleteClient(null, context, "c1");
+
+                client = await clientStore.GetClientAsync("x", "c1");
+                Assert.IsNull(client);
+
+                var thrown = false;
+
+                try
+                {
+                    await ClientStoreOperations.DeleteClient(null, context, "nonexisting");
+                }
+                catch (InvalidOperationException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_DeleteClient_PublicAdmin()
+        {
+            return ClientStoreTestForPublicAdmin(async (context, clientStore) =>
+            {
+                var client = await clientStore.GetClientAsync("x", "c3");
+                Assert.IsNotNull(client);
+                client = await clientStore.GetClientAsync("x", "c4");
+                Assert.IsNotNull(client);
+
+                await ClientStoreOperations.DeleteClient(null, context, "c3");
+                await ClientStoreOperations.DeleteClient(null, context, "c4");
+
+                client = await clientStore.GetClientAsync("x", "c3");
+                Assert.IsNull(client);
+
+                client = await clientStore.GetClientAsync("x", "c4");
+                Assert.IsNull(client);
+
+                var thrown = false;
+
+                try
+                {
+                    // delete admin client: NOT OK
+                    await ClientStoreOperations.DeleteClient(null, context, "c1");
+                }
+                catch (SenseNetSecurityException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+
+                thrown = false;
+
+                try
+                {
+                    // delete other users' client: NOT OK
+                    await ClientStoreOperations.DeleteClient(null, context, "c5");
+                }
+                catch (SenseNetSecurityException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+
+        [TestMethod, TestCategory("ClientStore")]
+        public Task ClientStore_RegenerateSecret_PublicAdmin()
+        {
+            return ClientStoreTestForPublicAdmin(async (context, _) =>
+            {
+                var secret1 = await ClientStoreOperations.CreateSecret(null, context, "c3");
+                var secret2 = await ClientStoreOperations.RegenerateSecretForRepository(null, context, "c3", secret1.Id);
+
+                Assert.AreEqual(secret1.Id, secret2.Id);
+                Assert.AreNotEqual(secret1.Value, secret2.Value);
+
+                var thrown = false;
+
+                try
+                {
+                    // try to access an admin client secret
+                    await ClientStoreOperations.RegenerateSecretForRepository(null, context, "c1", "?");
+                }
+                catch (SenseNetSecurityException)
+                {
+                    thrown = true;
+                }
+
+                Assert.IsTrue(thrown);
+            });
+        }
+
+        // Helper methods ===================================================================================
+
+        protected Task ClientStoreTest(Func<HttpContext, ClientStore, Task> callback)
+        {
+            ClientStore clientStore = null;
+            IServiceProvider services = null;
+
+            return Test2(sc =>
+                {
+                    sc.Configure<ClientStoreOptions>(options =>
+                    {
+                        options.Authority = "x";
+                        options.RepositoryUrl = "x";
+                    });
+                },
+                repoBuilder =>
+                {
+                    clientStore = repoBuilder.Services.GetRequiredService<ClientStore>();
+                    services = repoBuilder.Services;
+                }, async () =>
+                {
+                    var context = new DefaultHttpContext { RequestServices = services };
+
+                    await CreateUsersAndClients(clientStore);
+                    await callback(context, clientStore);
+                });
+        }
+        protected Task ClientStoreTestForPublicAdmin(Func<HttpContext, ClientStore, Task> callback)
+        {
+            return ClientStoreTest(async (context, clientStore) =>
+            {
+                var testUser = await Node.LoadAsync<User>(Identifiers.PublicAdminPath, CancellationToken.None);
+                var originalUser = AccessProvider.Current.GetCurrentUser();
+
+                AccessProvider.Current.SetCurrentUser(testUser);
+
+                try
+                {
+                    await callback(context, clientStore);
+                }
+                finally
+                {
+                    AccessProvider.Current.SetCurrentUser(originalUser);
+                }
+            });
+        }
+        protected Task ClientStoreTestForRegularUser(Func<HttpContext, ClientStore, Task> callback)
+        {
+            return ClientStoreTest(async (context, clientStore) =>
+            {
+                var testUser = await Node.LoadAsync<User>("/Root/IMS/domain2/user2", CancellationToken.None);
+                var originalUser = AccessProvider.Current.GetCurrentUser();
+
+                AccessProvider.Current.SetCurrentUser(testUser);
+
+                try
+                {
+                    await callback(context, clientStore);
+                }
+                finally
+                {
+                    AccessProvider.Current.SetCurrentUser(originalUser);
+                }
+            });
+        }
+
+        private static async Task CreateUsersAndClients(ClientStore clientStore)
+        {
+            // public\user1     --> member of PublicAdmins
+            // domain2\user2
+
+            var publicDomain = Node.Load<Domain>("/Root/IMS/Public");
+            var user1Content = Content.CreateNew("User", publicDomain, "user1");
+            user1Content["Enabled"] = true;
+
+            await user1Content.SaveAsync(CancellationToken.None);
+            var user1 = user1Content.ContentHandler as User;
+
+            var publicAdminGroup =
+                await Node.LoadAsync<Group>(ApplicationModel.N.R.PublicAdministrators, CancellationToken.None);
+
+            publicAdminGroup.AddMember(user1);
+
+            var domain2 = Content.CreateNew("Domain", Node.LoadNode("/Root/IMS"), "domain2");
+            await domain2.SaveAsync(CancellationToken.None);
+
+            var user2 = Content.CreateNew("User", domain2.ContentHandler, "user2");
+            await user2.SaveAsync(CancellationToken.None);
+
+            await clientStore.SaveClientAsync(new Client
+            {
+                Name = "c1",
+                ClientId = "c1",
+                Authority = "x",
+                UserName = "builtin\\admin",
+                Type = ClientType.InternalClient,
+                Repository = "x"
+            });
+            await clientStore.SaveClientAsync(new Client
+            {
+                Name = "c2",
+                ClientId = "c2",
+                Authority = "x",
+                Type = ClientType.ExternalSpa,
+                Repository = "x"
+            });
+            await clientStore.SaveClientAsync(new Client
+            {
+                Name = "c3",
+                ClientId = "c3",
+                Authority = "x",
+                UserName = "builtin\\publicadmin",
+                Type = ClientType.ExternalClient,
+                Repository = "x"
+            });
+            await clientStore.SaveClientAsync(new Client
+            {
+                Name = "c4",
+                ClientId = "c4",
+                Authority = "x",
+                UserName = "public\\user1",
+                Type = ClientType.ExternalClient,
+                Repository = "x"
+            });
+            await clientStore.SaveClientAsync(new Client
+            {
+                Name = "c5",
+                ClientId = "c5",
+                Authority = "x",
+                UserName = "domain2\\user2",
+                Type = ClientType.ExternalClient,
+                Repository = "x"
+            });
+        }
+    }
+}

--- a/src/WebHooks/StatisticsOperations.cs
+++ b/src/WebHooks/StatisticsOperations.cs
@@ -231,7 +231,7 @@ namespace SenseNet.WebHooks
         /// <returns>A list of webhook usage records.</returns>
         [ODataFunction(operationName: "GetWebHookUsageList")]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<IEnumerable<WebHookUsageListItemViewModel>> GetAllWebHookUsageList(Content content, HttpContext httpContext,
           DateTime? maxTime = null, int count = 10)
         {
@@ -262,7 +262,7 @@ namespace SenseNet.WebHooks
         /// <returns>A list of webhook usage records.</returns>
         [ODataFunction]
         [ContentTypes("WebHookSubscription")]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<IEnumerable<WebHookUsageListItemViewModel>> GetWebHookUsageList(Content content, HttpContext httpContext,
             DateTime? maxTime = null, int count = 10)
         {
@@ -289,7 +289,7 @@ namespace SenseNet.WebHooks
         /// <returns>A webhook statistical data containing start and end dates and count of records.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static Task<object> GetWebHookUsagePeriods(Content content, HttpContext httpContext,
             TimeWindow? timeWindow = null)
         {
@@ -363,7 +363,7 @@ namespace SenseNet.WebHooks
         /// <returns>WebHook data containing time window information and a list of aggregated data points.</returns>
         [ODataFunction]
         [ContentTypes(N.CT.PortalRoot)]
-        [AllowedRoles(N.R.Administrators, N.R.Developers)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators, N.R.Developers)]
         public static async Task<object> GetWebHookUsagePeriod(Content content, HttpContext httpContext,
             TimeWindow? timeWindow = null, DateTime? time = null)
         {

--- a/src/WebHooks/WebHookOperations.cs
+++ b/src/WebHooks/WebHookOperations.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using SenseNet.ApplicationModel;
@@ -25,7 +22,7 @@ namespace SenseNet.WebHooks
         /// <returns>The webhook subscription that was fired.</returns>
         [ODataAction]
         [ContentTypes("WebHookSubscription")]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static async Task<Content> FireWebHook(Content webHookContent, HttpContext context, string path, WebHookEventType eventType)
         {
             await FireWebHook(context, (WebHookSubscription) webHookContent.ContentHandler, Node.LoadNode(path),
@@ -46,7 +43,7 @@ namespace SenseNet.WebHooks
         /// <returns>The webhook subscription that was fired.</returns>
         [ODataAction]
         [ContentTypes("WebHookSubscription")]
-        [AllowedRoles(N.R.Administrators)]
+        [AllowedRoles(N.R.Administrators, N.R.PublicAdministrators)]
         public static async Task<Content> FireWebHook(Content webHookContent, HttpContext context, int nodeId, WebHookEventType eventType)
         {
             await FireWebHook(context, (WebHookSubscription)webHookContent.ContentHandler, Node.LoadNode(nodeId),


### PR DESCRIPTION
- allow public administrators to access essential OData operations
- handle complex client/secret scenarios for public admin users