### PR TITLE
Add missing json converters to the services

### DIFF
--- a/src/ContentRepository/SnMessageFormatterExtensions.cs
+++ b/src/ContentRepository/SnMessageFormatterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using SenseNet.ApplicationModel;
 using SenseNet.Communication.Messaging;
 using SenseNet.ContentRepository;
@@ -8,12 +9,19 @@ using SenseNet.ContentRepository.Search.Indexing.Activities;
 using SenseNet.ContentRepository.Storage;
 using SenseNet.ContentRepository.Storage.Caching.Dependency;
 using SenseNet.ContentRepository.Storage.Caching.DistributedActions;
+using SenseNet.Search.Indexing;
 
 // ReSharper disable once CheckNamespace
 namespace SenseNet.Extensions.DependencyInjection
 {
     public static class SnMessageFormatterExtensions
     {
+        public static IServiceCollection AddDefaultJsonConverters(this IServiceCollection services)
+        {
+            return services
+                    .AddSingleton<JsonConverter, IndexFieldJsonConverter>()
+                ;
+        }
         public static IServiceCollection AddDefaultClusterMessageTypes(this IServiceCollection services)
         {
             return services

--- a/src/Search/Indexing/IndexFieldJsonConverter.cs
+++ b/src/Search/Indexing/IndexFieldJsonConverter.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace SenseNet.Search.Indexing
 {
-    internal class IndexFieldJsonConverter : JsonConverter<IndexField>
+    public class IndexFieldJsonConverter : JsonConverter<IndexField>
     {
         public override void WriteJson(JsonWriter writer, IndexField value, JsonSerializer serializer)
         {

--- a/src/Services.Core/ServicesExtensions.cs
+++ b/src/Services.Core/ServicesExtensions.cs
@@ -167,6 +167,7 @@ namespace SenseNet.Extensions.DependencyInjection
 
                 .AddSingleton(ClusterMemberInfo.Current)
                 .AddDefaultClusterMessageTypes()
+                .AddDefaultJsonConverters()
                 .AddSingleton<IClusterMessageFormatter, SnMessageFormatter>()
                 .AddSingleton<IClusterChannel, VoidChannel>()
 

--- a/src/Tests/SenseNet.ContentRepository.Tests/ClusterMessageTests.cs
+++ b/src/Tests/SenseNet.ContentRepository.Tests/ClusterMessageTests.cs
@@ -84,9 +84,9 @@ namespace SenseNet.ContentRepository.Tests
         private async STT.Task SerializationTest<T>(T message, Action<T> assertion) where T : ClusterMessage
         {
             var services = new ServiceCollection()
-                .AddSingleton<IEnumerable<JsonConverter>>(new JsonConverter[] {new IndexFieldJsonConverter()})
                 .AddSingleton(ClusterMemberInfo.Current)
                 .AddDefaultClusterMessageTypes()
+                .AddDefaultJsonConverters()
                 .AddSingleton<IClusterMessageFormatter, SnMessageFormatter>()
                 .AddSingleton<IClusterChannel, TestClusterChannel>()
                 .AddSingleton<IIndexManager, TestIndexManager>()

--- a/src/Tests/WebAppTests/ServicesTests.cs
+++ b/src/Tests/WebAppTests/ServicesTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using SenseNet.AI.Text;
 using SenseNet.AI.Text.SemanticKernel;
 using SenseNet.AI.Vision;
@@ -423,6 +424,7 @@ namespace WebAppTests
                 }},
                 {typeof(TextExtractorRegistration), typeof(TextExtractorRegistration) },
 
+                {typeof(JsonConverter), typeof(IndexFieldJsonConverter)},
                 {typeof(IClusterMessageFormatter), typeof(SnMessageFormatter)},
                 {typeof(ClusterMemberInfo), typeof(ClusterMemberInfo)},
                 {typeof(IClusterChannel), typeof(VoidChannel)},


### PR DESCRIPTION
Use the new AddDefaultJsonConverters extension method in the AddPlatformIndependentServices. This ensures that the SnMessageFormatter can deserialize the IndexDocument.