### PR TITLE
Fix: Manual CORS header injection and detailed logging in BinaryMiddleware for cross-origin requests

### DIFF
--- a/src/Services.Core/Virtualization/BinaryMiddleware.cs
+++ b/src/Services.Core/Virtualization/BinaryMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Threading.Tasks;
 using SenseNet.Services.Core.Diagnostics;
 
@@ -10,21 +13,117 @@ namespace SenseNet.Services.Core.Virtualization
     public class BinaryMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly ICorsPolicyProvider _corsPolicyProvider;
+        private readonly ILogger<BinaryMiddleware> _logger;
         
-        public BinaryMiddleware(RequestDelegate next)
+        public BinaryMiddleware(RequestDelegate next, ICorsPolicyProvider corsPolicyProvider = null, ILogger<BinaryMiddleware> logger = null)
         {
             _next = next;
+            _corsPolicyProvider = corsPolicyProvider;
+            _logger = logger;
         }
 
         public async Task InvokeAsync(HttpContext httpContext, WebTransferRegistrator statistics)
         {
+            _logger?.LogInformation("=== BinaryMiddleware START ===");
+            _logger?.LogInformation("Request Path: {Path}", httpContext.Request.Path);
+            _logger?.LogInformation("Request Method: {Method}", httpContext.Request.Method);
+            
+            // Apply CORS policy manually since MapMiddlewareWhen creates a separate branch 
+            // that bypasses the UseSenseNetCors middleware
+            if (_corsPolicyProvider != null)
+            {
+                _logger?.LogInformation("CORS Policy Provider is available");
+                
+                var corsPolicy = await _corsPolicyProvider.GetPolicyAsync(httpContext, "sensenet");
+                if (corsPolicy != null)
+                {
+                    _logger?.LogInformation("CORS Policy retrieved successfully");
+                    _logger?.LogInformation("CORS Policy - AllowAnyOrigin: {AllowAnyOrigin}", corsPolicy.AllowAnyOrigin);
+                    _logger?.LogInformation("CORS Policy - SupportsCredentials: {SupportsCredentials}", corsPolicy.SupportsCredentials);
+                    _logger?.LogInformation("CORS Policy - Origins: {Origins}", string.Join(", ", corsPolicy.Origins));
+                    
+                    // Apply CORS headers based on the policy
+                    var origin = httpContext.Request.Headers["Origin"].FirstOrDefault();
+                    _logger?.LogInformation("Request Origin header: '{Origin}'", origin ?? "NULL");
+                    
+                    if (!string.IsNullOrEmpty(origin))
+                    {
+                        // Check if the origin is allowed (either matches exactly or policy allows any origin)
+                        var isAllowed = corsPolicy.Origins.Contains(origin) || 
+                                      corsPolicy.Origins.Contains("*") ||
+                                      corsPolicy.AllowAnyOrigin;
+                        
+                        _logger?.LogInformation("Origin is allowed: {IsAllowed}", isAllowed);
+                        
+                        if (isAllowed)
+                        {
+                            // For any origin (*), we can only return * if credentials are NOT supported
+                            if (corsPolicy.AllowAnyOrigin || corsPolicy.Origins.Contains("*"))
+                            {
+                                if (!corsPolicy.SupportsCredentials)
+                                {
+                                    httpContext.Response.Headers.Append("Access-Control-Allow-Origin", "*");
+                                    _logger?.LogInformation("Added CORS header: Access-Control-Allow-Origin = *");
+                                }
+                                else
+                                {
+                                    httpContext.Response.Headers.Append("Access-Control-Allow-Origin", origin);
+                                    _logger?.LogInformation("Added CORS header: Access-Control-Allow-Origin = {Origin}", origin);
+                                }
+                            }
+                            else
+                            {
+                                httpContext.Response.Headers.Append("Access-Control-Allow-Origin", origin);
+                                _logger?.LogInformation("Added CORS header: Access-Control-Allow-Origin = {Origin}", origin);
+                            }
+                            
+                            if (corsPolicy.SupportsCredentials)
+                            {
+                                httpContext.Response.Headers.Append("Access-Control-Allow-Credentials", "true");
+                                _logger?.LogInformation("Added CORS header: Access-Control-Allow-Credentials = true");
+                            }
+                            
+                            if (corsPolicy.ExposedHeaders.Count > 0)
+                            {
+                                var exposedHeaders = string.Join(", ", corsPolicy.ExposedHeaders);
+                                httpContext.Response.Headers.Append("Access-Control-Expose-Headers", exposedHeaders);
+                                _logger?.LogInformation("Added CORS header: Access-Control-Expose-Headers = {Headers}", exposedHeaders);
+                            }
+                        }
+                        else
+                        {
+                            _logger?.LogWarning("Origin '{Origin}' is NOT allowed by CORS policy", origin);
+                        }
+                    }
+                    else
+                    {
+                        _logger?.LogInformation("No Origin header in request");
+                    }
+                }
+                else
+                {
+                    _logger?.LogWarning("CORS Policy is NULL - could not retrieve policy");
+                }
+            }
+            else
+            {
+                _logger?.LogWarning("CORS Policy Provider is NULL - CORS headers will NOT be added");
+            }
+
             var statData = statistics?.RegisterWebRequest(httpContext);
 
             var bh = new BinaryHandler(httpContext);
 
             await bh.ProcessRequestCore().ConfigureAwait(false);
+            
+            _logger?.LogInformation("Response Status Code: {StatusCode}", httpContext.Response.StatusCode);
+            _logger?.LogInformation("Response Headers: {Headers}", 
+                string.Join("; ", httpContext.Response.Headers.Select(h => $"{h.Key}={h.Value}")));
 
             statistics?.RegisterWebResponse(statData, httpContext);
+            
+            _logger?.LogInformation("=== BinaryMiddleware END ===");
 
             // Call next middleware in the chain if exists
             if (_next != null)


### PR DESCRIPTION
This branch introduces a targeted fix for cross-origin requests to the binaryhandler.ashx endpoint in SenseNet. It ensures that CORS headers are manually injected in the BinaryMiddleware for GET requests, allowing React and other frontends to fetch images and files from the backend without CORS errors.

Key changes:
- Manually injects CORS headers in BinaryMiddleware for binaryhandler.ashx requests, supporting dynamic allowed origins and credentials.
- Adds detailed logging for request paths, methods, CORS policy evaluation, and header injection, aiding debugging and cross-project testing.
- Retains verbose logs to help diagnose CORS and browser cache issues (pending company decision to remove or reduce logging).

This fix resolves issues where browser cache or pipeline branching prevented proper CORS header delivery, and enables successful cross-origin file access from modern frontends.